### PR TITLE
Pre-go-live hardening: cross-platform CI, rate-limit fix, --debug observability, fuzz tests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,9 @@ updates:
       github-actions:
         patterns:
           - "*"
+        update-types:
+          - minor
+          - patch
 
   - package-ecosystem: gomod
     directory: /

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "07:00"
+      timezone: Europe/Istanbul
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "07:10"
+      timezone: Europe/Istanbul
+    open-pull-requests-limit: 5
+    groups:
+      go-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,38 +10,22 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 defaults:
   run:
     shell: bash
 
 jobs:
-  dependencies:
-    name: dependencies
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          persist-credentials: false
-      - uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
-          cache: true
-          cache-dependency-path: go.sum
-      - name: Verify dependencies
-        run: go mod download
-
   generated-client:
     name: generated client
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
           cache: true
@@ -54,20 +38,16 @@ jobs:
           git diff --exit-code -- internal/client/generated.go
 
   test:
-    name: test / go ${{ matrix.go-version }}
+    name: test
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    strategy:
-      fail-fast: false
-      matrix:
-        go-version: ["1.26.x", "stable"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version-file: go.mod
           cache: true
           cache-dependency-path: go.sum
       - name: Verify dependencies
@@ -84,10 +64,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
           cache: true
@@ -102,10 +82,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
           cache: true
@@ -120,10 +100,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
           cache: true
@@ -138,24 +118,23 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs:
-      - dependencies
       - generated-client
       - test
       - coverage
       - lint
       - security
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
           cache: true
           cache-dependency-path: go.sum
       - name: Verify release build
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         with:
           distribution: goreleaser
           version: "~> v2"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Vet
         run: go vet $(bash scripts/go-packages.sh)
       - name: Test
-        run: go test ${{ matrix.race }} -shuffle=on -count=1 $(bash scripts/go-packages.sh)
+        run: go test ${{ matrix.race }} -shuffle=on -count=1 -timeout 180s $(bash scripts/go-packages.sh)
       - name: Build
         run: go build $(bash scripts/go-packages.sh)
       - name: Smoke run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,9 +38,19 @@ jobs:
           git diff --exit-code -- internal/client/generated.go
 
   test:
-    name: test
-    runs-on: ubuntu-latest
+    name: test / ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            race: "-race"
+          - os: macos-latest
+            race: "-race"
+          - os: windows-latest
+            race: ""
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -55,9 +65,13 @@ jobs:
       - name: Vet
         run: go vet $(bash scripts/go-packages.sh)
       - name: Test
-        run: go test -race -shuffle=on -count=1 $(bash scripts/go-packages.sh)
+        run: go test ${{ matrix.race }} -shuffle=on -count=1 $(bash scripts/go-packages.sh)
       - name: Build
         run: go build $(bash scripts/go-packages.sh)
+      - name: Smoke run
+        run: |
+          go run ./cmd/linctl --version
+          go run ./cmd/linctl --help
 
   coverage:
     name: coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,28 +5,160 @@ on:
   push:
     branches: [master, main]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
 jobs:
-  ci:
+  dependencies:
+    name: dependencies
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true
+          cache-dependency-path: go.sum
+      - name: Verify dependencies
+        run: go mod download
+
+  generated-client:
+    name: generated client
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+          cache-dependency-path: go.sum
       - name: Verify dependencies
         run: go mod download
       - name: Verify generated client
         run: |
           go generate ./...
           git diff --exit-code -- internal/client/generated.go
-      - name: Build
-        run: go build $(bash scripts/go-packages.sh)
+
+  test:
+    name: test / go ${{ matrix.go-version }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        go-version: ["1.26.x", "stable"]
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@v6
+        with:
+          go-version: ${{ matrix.go-version }}
+          cache: true
+          cache-dependency-path: go.sum
+      - name: Verify dependencies
+        run: go mod download
       - name: Vet
         run: go vet $(bash scripts/go-packages.sh)
       - name: Test
         run: go test -race -shuffle=on -count=1 $(bash scripts/go-packages.sh)
+      - name: Build
+        run: go build $(bash scripts/go-packages.sh)
+
+  coverage:
+    name: coverage
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+          cache-dependency-path: go.sum
+      - name: Verify dependencies
+        run: go mod download
+      - name: Verify hand-written coverage
+        run: bash scripts/coverage.sh
+
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+          cache-dependency-path: go.sum
+      - name: Verify dependencies
+        run: go mod download
       - name: golangci-lint
         run: go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --timeout 5m $(bash scripts/go-packages.sh)
+
+  security:
+    name: security
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+          cache-dependency-path: go.sum
+      - name: Verify dependencies
+        run: go mod download
       - name: Vulnerability scan
         run: go tool govulncheck $(bash scripts/go-packages.sh)
+
+  release-snapshot:
+    name: release snapshot
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs:
+      - dependencies
+      - generated-client
+      - test
+      - coverage
+      - lint
+      - security
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+          cache-dependency-path: go.sum
+      - name: Verify release build
+        uses: goreleaser/goreleaser-action@v7
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --snapshot --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,20 +6,72 @@ on:
       - "v*"
 
 permissions:
-  contents: write
+  contents: read
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+defaults:
+  run:
+    shell: bash
 
 jobs:
-  release:
+  preflight:
+    name: preflight
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true
-      - uses: goreleaser/goreleaser-action@v6
+          cache-dependency-path: go.sum
+      - name: Verify dependencies
+        run: go mod download
+      - name: Verify generated client
+        run: |
+          go generate ./...
+          git diff --exit-code -- internal/client/generated.go
+      - name: Vet
+        run: go vet $(bash scripts/go-packages.sh)
+      - name: Test
+        run: go test -race -shuffle=on -count=1 $(bash scripts/go-packages.sh)
+      - name: Build
+        run: go build $(bash scripts/go-packages.sh)
+      - name: golangci-lint
+        run: go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --timeout 5m $(bash scripts/go-packages.sh)
+      - name: Vulnerability scan
+        run: go tool govulncheck $(bash scripts/go-packages.sh)
+      - name: Verify GoReleaser config
+        uses: goreleaser/goreleaser-action@v7
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: check
+
+  publish:
+    name: publish
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    needs: preflight
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+          cache-dependency-path: go.sum
+      - uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
           version: "~> v2"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,11 +22,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
           cache: true
@@ -48,7 +48,7 @@ jobs:
       - name: Vulnerability scan
         run: go tool govulncheck $(bash scripts/go-packages.sh)
       - name: Verify GoReleaser config
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         with:
           distribution: goreleaser
           version: "~> v2"
@@ -62,16 +62,16 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
           cache: true
           cache-dependency-path: go.sum
-      - uses: goreleaser/goreleaser-action@v7
+      - uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         with:
           distribution: goreleaser
           version: "~> v2"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ Guarded writes fail closed on Target Mismatch — a hard stop, never a soft warn
 
 `task` is not installed locally — run it via `go run github.com/go-task/task/v3/cmd/task@latest <task>`, or install go-task.
 
-- `task ci` — local gate before any PR: generate-check → vet → test → build → lint.
+- `task ci` — local gate before any PR: generate-check → vet → test → build → lint → vuln.
 - `task coverage` — enforces **100% hand-written statement coverage** for product code (excludes `internal/client/generated.go`, `cmd/linctl/main.go`, and repo maintenance scripts under `scripts/`). Not part of `task ci`; run it separately and keep new product code fully covered.
 - `task fmt` — gofumpt + goimports (NOT plain gofmt); both must be installed.
 - `task lint` — golangci-lint v2.12.2 (pinned; ~30 linters incl. gocognit/gocyclo/funlen/lll-120/gosec). Keep functions small and typed.

--- a/internal/cli/coverage_test.go
+++ b/internal/cli/coverage_test.go
@@ -2683,6 +2683,7 @@ func Test_CommandRuntime_reports_config_load_errors(t *testing.T) {
 
 func Test_DefaultGlobalConfigPath_returns_empty_when_home_is_unset(t *testing.T) {
 	t.Setenv("HOME", "")
+	t.Setenv("USERPROFILE", "") // Windows resolves the home dir from USERPROFILE, not HOME.
 
 	require.Empty(t, defaultGlobalConfigPath())
 }

--- a/internal/cli/logging.go
+++ b/internal/cli/logging.go
@@ -1,10 +1,50 @@
 package cli
 
 import (
+	"errors"
 	"io"
 	"log/slog"
 	"strings"
+
+	"github.com/KyaniteHQ/linctl/internal/client"
 )
+
+// discardLogger is the fallback for runtimes built without a logger (test
+// fakes), so logging call-sites never need a nil check.
+var discardLogger = slog.New(slog.DiscardHandler)
+
+// log returns the runtime logger, or a discarding logger when one was not set.
+func (runtime commandRuntime) log() *slog.Logger {
+	if runtime.logger == nil {
+		return discardLogger
+	}
+
+	return runtime.logger
+}
+
+// logTargetResolution records the outcome of a target resolution at debug
+// level. The mismatch attribute flags a Target Mismatch refusal versus an
+// unrelated resolve error; the underlying error is already surfaced to the
+// user by the command, so this stays at debug rather than warn.
+func logTargetResolution(logger *slog.Logger, target client.ResolvedTarget, err error) {
+	if err != nil {
+		logger.Debug(
+			"target unresolved",
+			"mismatch", errors.Is(err, client.ErrTargetMismatch),
+			"error", err.Error(),
+		)
+
+		return
+	}
+
+	logger.Debug(
+		"target resolved",
+		"org", target.Org.ID,
+		"team_id", target.Team.ID,
+		"team_key", target.Team.Key,
+		"confirmed", target.Confirmed,
+	)
+}
 
 // newDiagnosticLogger builds the stderr diagnostic logger. Without --debug it
 // emits warnings and above (for example an insecure-config notice); with

--- a/internal/cli/logging.go
+++ b/internal/cli/logging.go
@@ -1,0 +1,47 @@
+package cli
+
+import (
+	"io"
+	"log/slog"
+	"strings"
+)
+
+// newDiagnosticLogger builds the stderr diagnostic logger. Without --debug it
+// emits warnings and above (for example an insecure-config notice); with
+// --debug it emits the full debug stream. LINCTL_DEBUG_JSON=1 selects JSON
+// output over the default text format.
+func newDiagnosticLogger(debug bool, jsonOutput bool, destination io.Writer) *slog.Logger {
+	level := slog.LevelWarn
+	if debug {
+		level = slog.LevelDebug
+	}
+
+	handlerOptions := &slog.HandlerOptions{Level: level}
+	if jsonOutput {
+		return slog.New(slog.NewJSONHandler(destination, handlerOptions))
+	}
+
+	return slog.New(slog.NewTextHandler(destination, handlerOptions))
+}
+
+// transportDiagnosticWriter forwards the transport's line diagnostics into the
+// slog stream at debug level so every diagnostic shares one sink and format.
+type transportDiagnosticWriter struct {
+	logger *slog.Logger
+}
+
+func (writer transportDiagnosticWriter) Write(payload []byte) (int, error) {
+	writer.logger.Debug("transport", "detail", strings.TrimRight(string(payload), "\n"))
+
+	return len(payload), nil
+}
+
+// newTransportDiagnosticWriter wires transport diagnostics into the logger only
+// under --debug; otherwise it returns nil so the transport stays silent.
+func newTransportDiagnosticWriter(logger *slog.Logger, debug bool) io.Writer {
+	if !debug {
+		return nil
+	}
+
+	return transportDiagnosticWriter{logger: logger}
+}

--- a/internal/cli/logging_test.go
+++ b/internal/cli/logging_test.go
@@ -3,10 +3,14 @@ package cli
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"io"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/KyaniteHQ/linctl/internal/client"
 )
 
 func Test_newDiagnosticLogger_debug_emits_text_diagnostics(t *testing.T) {
@@ -61,4 +65,47 @@ func Test_newTransportDiagnosticWriter_forwards_trimmed_lines_under_debug(t *tes
 
 func Test_newTransportDiagnosticWriter_is_nil_without_debug(t *testing.T) {
 	require.Nil(t, newTransportDiagnosticWriter(newDiagnosticLogger(false, false, io.Discard), false))
+}
+
+func Test_commandRuntime_log_falls_back_to_discard_logger(t *testing.T) {
+	require.Same(t, discardLogger, commandRuntime{}.log())
+
+	logger := newDiagnosticLogger(true, false, io.Discard)
+	require.Same(t, logger, commandRuntime{logger: logger}.log())
+}
+
+func Test_logTargetResolution_marks_target_mismatch(t *testing.T) {
+	var buffer bytes.Buffer
+	logger := newDiagnosticLogger(true, false, &buffer)
+
+	logTargetResolution(logger, client.ResolvedTarget{}, fmt.Errorf("%w: org", client.ErrTargetMismatch))
+
+	require.Contains(t, buffer.String(), "msg=\"target unresolved\"")
+	require.Contains(t, buffer.String(), "mismatch=true")
+}
+
+func Test_logTargetResolution_marks_non_mismatch_errors(t *testing.T) {
+	var buffer bytes.Buffer
+	logger := newDiagnosticLogger(true, false, &buffer)
+
+	logTargetResolution(logger, client.ResolvedTarget{}, errors.New("resolve viewer failed"))
+
+	require.Contains(t, buffer.String(), "msg=\"target unresolved\"")
+	require.Contains(t, buffer.String(), "mismatch=false")
+}
+
+func Test_logTargetResolution_records_resolved_target(t *testing.T) {
+	var buffer bytes.Buffer
+	logger := newDiagnosticLogger(true, false, &buffer)
+
+	logTargetResolution(logger, client.ResolvedTarget{
+		Org:       client.TargetOrg{ID: "org-id"},
+		Team:      client.TargetTeam{ID: "team-id", Key: "LIT"},
+		Confirmed: true,
+	}, nil)
+
+	output := buffer.String()
+	require.Contains(t, output, "msg=\"target resolved\"")
+	require.Contains(t, output, "team_key=LIT")
+	require.Contains(t, output, "confirmed=true")
 }

--- a/internal/cli/logging_test.go
+++ b/internal/cli/logging_test.go
@@ -1,0 +1,64 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_newDiagnosticLogger_debug_emits_text_diagnostics(t *testing.T) {
+	var buffer bytes.Buffer
+	logger := newDiagnosticLogger(true, false, &buffer)
+
+	logger.Debug("runtime ready", "team_key", "LIT")
+
+	output := buffer.String()
+	require.Contains(t, output, "level=DEBUG")
+	require.Contains(t, output, "msg=\"runtime ready\"")
+	require.Contains(t, output, "team_key=LIT")
+}
+
+func Test_newDiagnosticLogger_without_debug_drops_debug_but_keeps_warnings(t *testing.T) {
+	var buffer bytes.Buffer
+	logger := newDiagnosticLogger(false, false, &buffer)
+
+	logger.Debug("debug line")
+	require.Empty(t, buffer.String())
+
+	logger.Warn("config world-readable")
+	require.Contains(t, buffer.String(), "level=WARN")
+	require.Contains(t, buffer.String(), "config world-readable")
+}
+
+func Test_newDiagnosticLogger_json_output_is_structured(t *testing.T) {
+	var buffer bytes.Buffer
+	logger := newDiagnosticLogger(true, true, &buffer)
+
+	logger.Debug("graphql_retry", "attempt", 2)
+
+	var entry map[string]any
+	require.NoError(t, json.Unmarshal(buffer.Bytes(), &entry))
+	require.Equal(t, "graphql_retry", entry["msg"])
+	require.Equal(t, "DEBUG", entry["level"])
+	require.InEpsilon(t, float64(2), entry["attempt"], 0)
+}
+
+func Test_newTransportDiagnosticWriter_forwards_trimmed_lines_under_debug(t *testing.T) {
+	var buffer bytes.Buffer
+	writer := newTransportDiagnosticWriter(newDiagnosticLogger(true, false, &buffer), true)
+	require.NotNil(t, writer)
+
+	line := []byte("graphql_response attempt=1 status=200\n")
+	count, err := writer.Write(line)
+
+	require.NoError(t, err)
+	require.Equal(t, len(line), count)
+	require.Contains(t, buffer.String(), `detail="graphql_response attempt=1 status=200"`)
+}
+
+func Test_newTransportDiagnosticWriter_is_nil_without_debug(t *testing.T) {
+	require.Nil(t, newTransportDiagnosticWriter(newDiagnosticLogger(false, false, io.Discard), false))
+}

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -209,6 +209,9 @@ func projectCollection(raw map[string]any, paths [][]string) (map[string]any, bo
 		"agent_skills",
 		"external_users",
 		"audit_entry_types",
+		"favorites",
+		"emojis",
+		"attachments",
 	} {
 		items, ok := raw[key].([]any)
 		if !ok {

--- a/internal/cli/output_fuzz_test.go
+++ b/internal/cli/output_fuzz_test.go
@@ -1,0 +1,79 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// FuzzProjectJSONFields asserts the field projection parser never panics on
+// arbitrary --fields strings and always returns a non-nil value on success.
+func FuzzProjectJSONFields(f *testing.F) {
+	seeds := []string{
+		"",
+		"id",
+		"id,name",
+		"nested.deep.leaf",
+		" , , ",
+		"id,,name",
+		"...",
+		"a.",
+		".b",
+		"issues",
+		"missing.path.here",
+	}
+	for _, seed := range seeds {
+		f.Add(seed)
+	}
+
+	value := map[string]any{
+		"id":     "x",
+		"name":   "y",
+		"nested": map[string]any{"deep": map[string]any{"leaf": 1}},
+		"issues": []any{map[string]any{"id": "i1", "name": "n1"}},
+	}
+
+	f.Fuzz(func(t *testing.T, fields string) {
+		result, err := projectJSONFields(value, fields)
+		if err != nil {
+			return
+		}
+
+		require.NotNil(t, result)
+	})
+}
+
+// FuzzSortByJSONField asserts the list sorter never panics on arbitrary field
+// and order strings and preserves the element count whenever it succeeds.
+func FuzzSortByJSONField(f *testing.F) {
+	seeds := []struct {
+		field string
+		order string
+	}{
+		{field: "", order: "asc"},
+		{field: "id", order: "asc"},
+		{field: "id", order: "desc"},
+		{field: "name", order: "sideways"},
+		{field: "missing", order: "asc"},
+		{field: "nested.leaf", order: "desc"},
+		{field: ".", order: ""},
+	}
+	for _, seed := range seeds {
+		f.Add(seed.field, seed.order)
+	}
+
+	items := []map[string]any{
+		{"id": "2", "name": "b", "nested": map[string]any{"leaf": "y"}},
+		{"id": "1", "name": "a", "nested": map[string]any{"leaf": "x"}},
+		{"id": "3", "name": "c", "nested": map[string]any{"leaf": "z"}},
+	}
+
+	f.Fuzz(func(t *testing.T, field string, order string) {
+		sorted, err := sortByJSONField(items, field, order)
+		if err != nil {
+			return
+		}
+
+		require.Len(t, sorted, len(items))
+	})
+}

--- a/internal/cli/output_projection_test.go
+++ b/internal/cli/output_projection_test.go
@@ -1,0 +1,47 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Test_projectJSONFields_projects_list_envelopes guards that --json --fields
+// projects per item for every collection envelope the read commands emit.
+// The favorite/emoji/attachment envelopes were previously absent from the
+// projectCollection dispatch table, so projection fell through to the
+// single-object path and errored on the (missing) leaf field.
+func Test_projectJSONFields_projects_list_envelopes(t *testing.T) {
+	cases := []struct {
+		name string
+		key  string
+	}{
+		{name: "favorites", key: "favorites"},
+		{name: "emojis", key: "emojis"},
+		{name: "attachments", key: "attachments"},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			envelope := map[string]any{
+				testCase.key: []any{
+					map[string]any{"id": "id-1", "name": "first", "extra": "drop"},
+				},
+			}
+
+			projected, err := projectJSONFields(envelope, "id,name")
+
+			require.NoError(t, err)
+			result, ok := projected.(map[string]any)
+			require.True(t, ok)
+			items, ok := result[testCase.key].([]any)
+			require.True(t, ok)
+			require.Len(t, items, 1)
+			item, ok := items[0].(map[string]any)
+			require.True(t, ok)
+			require.Equal(t, "id-1", item["id"])
+			require.Equal(t, "first", item["name"])
+			require.NotContains(t, item, "extra")
+		})
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -32,6 +32,7 @@ type rootOptions struct {
 	orgID       string
 	team        string
 	project     string
+	debug       bool
 }
 
 // NewRootCommand builds the linctl root command.
@@ -64,6 +65,7 @@ func NewRootCommand(ctx context.Context, build BuildInfo) *cobra.Command {
 	flags.StringVar(&options.team, "team", "", "pinned Linear team key or id")
 	flags.StringVar(&options.project, "project", "", "pinned Linear project id")
 	flags.DurationVar(&options.timeout, "timeout", options.timeout, "request timeout")
+	flags.BoolVar(&options.debug, "debug", false, "emit debug diagnostics to stderr")
 
 	addCommands(ctx, command, &options)
 	command.SetContext(ctx)

--- a/internal/cli/runtime.go
+++ b/internal/cli/runtime.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"os"
 	"path/filepath"
 
@@ -15,11 +16,13 @@ import (
 type commandRuntime struct {
 	config        config.Resolved
 	graphqlClient graphql.Client
+	logger        *slog.Logger
 }
 
 var buildCommandRuntime = newCommandRuntime
 
 func newCommandRuntime(ctx context.Context, options *rootOptions) (commandRuntime, error) {
+	logger := newDiagnosticLogger(options.debug, os.Getenv("LINCTL_DEBUG_JSON") == "1", os.Stderr)
 	override := targetOverride(options)
 	resolvedConfig, err := config.Load(ctx, config.LoadRequest{
 		GlobalPath:      defaultGlobalConfigPath(),
@@ -34,11 +37,23 @@ func newCommandRuntime(ctx context.Context, options *rootOptions) (commandRuntim
 		return commandRuntime{}, errors.New("missing Linear token: set LINCTL_TOKEN or LINEAR_API_KEY")
 	}
 
+	logger.Debug(
+		"runtime ready",
+		"profile", resolvedConfig.Profile,
+		"org", resolvedConfig.Target.OrgID,
+		"team_key", resolvedConfig.Target.TeamKey,
+		"team_id", resolvedConfig.Target.TeamID,
+		"project", resolvedConfig.Target.ProjectID,
+		"timeout", options.timeout.String(),
+	)
+
 	return commandRuntime{
 		config: resolvedConfig,
+		logger: logger,
 		graphqlClient: client.NewTransport(client.TransportConfig{
-			Token:   client.PersonalAPIToken(resolvedConfig.Token),
-			Timeout: options.timeout,
+			Token:            client.PersonalAPIToken(resolvedConfig.Token),
+			Timeout:          options.timeout,
+			DiagnosticWriter: newTransportDiagnosticWriter(logger, options.debug),
 		}),
 	}, nil
 }

--- a/internal/cli/runtime.go
+++ b/internal/cli/runtime.go
@@ -59,7 +59,10 @@ func newCommandRuntime(ctx context.Context, options *rootOptions) (commandRuntim
 }
 
 func (runtime commandRuntime) resolveTarget(ctx context.Context) (client.ResolvedTarget, error) {
-	return client.ResolveTarget(ctx, runtime.graphqlClient, runtime.config.Target)
+	target, err := client.ResolveTarget(ctx, runtime.graphqlClient, runtime.config.Target)
+	logTargetResolution(runtime.log(), target, err)
+
+	return target, err
 }
 
 func defaultGlobalConfigPath() string {

--- a/internal/client/coverage_test.go
+++ b/internal/client/coverage_test.go
@@ -3733,6 +3733,8 @@ func Test_TransportScenarios_return_actionable_errors(t *testing.T) {
 	require.False(t, isRateLimited(http.StatusBadRequest, []byte(`{"errors":[{"extensions":{"code":"BAD_USER_INPUT"}}]}`)))
 	require.False(t, isRateLimited(http.StatusBadRequest, []byte("not json")))
 	require.False(t, isRateLimited(http.StatusOK, nil))
+	rateLimitedBody := []byte(`{"errors":[{"extensions":{"code":"RATELIMITED"}}]}`)
+	require.False(t, isRateLimited(http.StatusInternalServerError, rateLimitedBody))
 	require.ErrorIs(t, rateLimitError(http.StatusTooManyRequests, []byte("slow down")), ErrRateLimited)
 
 	response := graphql.Response{}

--- a/internal/client/coverage_test.go
+++ b/internal/client/coverage_test.go
@@ -3723,9 +3723,17 @@ func Test_TransportScenarios_return_actionable_errors(t *testing.T) {
 	require.Equal(t, "primary", firstNonEmpty("primary", "fallback"))
 	require.Equal(t, 3*time.Second, defaultDuration(3*time.Second, time.Second))
 	require.Equal(t, time.Second, defaultDuration(0, time.Second))
-	require.Equal(t, 200*time.Millisecond, retryDelay("", 1))
-	require.Equal(t, 100*time.Millisecond, retryDelay("not-a-number", 0))
-	require.Equal(t, 2*time.Second, retryDelay("2", 0))
+	require.Equal(t, 200*time.Millisecond, retryDelay(http.Header{}, 1))
+	require.Equal(t, 100*time.Millisecond, retryDelay(http.Header{"Retry-After": []string{"not-a-number"}}, 0))
+	require.Equal(t, 2*time.Second, retryDelay(http.Header{"Retry-After": []string{"2"}}, 0))
+	require.Equal(t, maxRetryDelay, retryDelay(http.Header{"Retry-After": []string{"120"}}, 0))
+
+	require.True(t, isRateLimited(http.StatusTooManyRequests, nil))
+	require.True(t, isRateLimited(http.StatusBadRequest, []byte(`{"errors":[{"extensions":{"code":"RATELIMITED"}}]}`)))
+	require.False(t, isRateLimited(http.StatusBadRequest, []byte(`{"errors":[{"extensions":{"code":"BAD_USER_INPUT"}}]}`)))
+	require.False(t, isRateLimited(http.StatusBadRequest, []byte("not json")))
+	require.False(t, isRateLimited(http.StatusOK, nil))
+	require.ErrorIs(t, rateLimitError(http.StatusTooManyRequests, []byte("slow down")), ErrRateLimited)
 
 	response := graphql.Response{}
 	err := decodeGraphQLResponse([]byte("not json"), http.StatusOK, &response)
@@ -3735,12 +3743,6 @@ func Test_TransportScenarios_return_actionable_errors(t *testing.T) {
 	err = decodeGraphQLResponse([]byte("server down"), http.StatusBadGateway, &response)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "graphql http status 502")
-
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-	_, err = waitForRateLimitRetry(ctx, http.StatusTooManyRequests, http.Header{}, 0, 1)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "wait for retry")
 }
 
 func Test_CustomViewPreferenceReads_return_empty_values_when_organization_defaults_are_absent(t *testing.T) {

--- a/internal/client/transport.go
+++ b/internal/client/transport.go
@@ -23,6 +23,10 @@ var ErrGraphQL = errors.New("graphql error")
 // ErrMutationFailed marks a mutation payload without success and entity id.
 var ErrMutationFailed = errors.New("mutation failed")
 
+// ErrRateLimited marks a Linear rate-limit response (HTTP 429 or an HTTP 400
+// carrying a RATELIMITED GraphQL error code) that survived all retries.
+var ErrRateLimited = errors.New("rate limited")
+
 // AuthToken formats the Linear Authorization header.
 type AuthToken struct {
 	authorization string
@@ -92,12 +96,15 @@ func (transport *Transport) MakeRequest(
 			return err
 		}
 		transport.log("graphql_response attempt=%d status=%d", attempt+1, statusCode)
-		retry, err := waitForRateLimitRetry(ctx, statusCode, header, attempt, transport.maxRetries)
-		if err != nil {
-			transport.log("graphql_retry_failed attempt=%d error=%q", attempt+1, err.Error())
-			return err
-		}
-		if retry {
+		if isRateLimited(statusCode, body) {
+			if attempt >= transport.maxRetries {
+				transport.log("graphql_rate_limited attempt=%d status=%d", attempt+1, statusCode)
+				return rateLimitError(statusCode, body)
+			}
+			if err := waitForRetry(ctx, retryDelay(header, attempt)); err != nil {
+				transport.log("graphql_retry_failed attempt=%d error=%q", attempt+1, err.Error())
+				return err
+			}
 			transport.log("graphql_retry attempt=%d status=%d", attempt+1, statusCode)
 			continue
 		}
@@ -121,21 +128,46 @@ func (transport *Transport) log(format string, args ...any) {
 	}
 }
 
-func waitForRateLimitRetry(
-	ctx context.Context,
-	statusCode int,
-	header http.Header,
-	attempt int,
-	maxRetries int,
-) (bool, error) {
-	if statusCode != http.StatusTooManyRequests || attempt >= maxRetries {
-		return false, nil
+// isRateLimited reports whether a response is a Linear rate-limit signal.
+// Linear answers HTTP 429 for some limits and HTTP 400 with a RATELIMITED
+// GraphQL error code for the documented per-key quota, so both are checked.
+func isRateLimited(statusCode int, body []byte) bool {
+	if statusCode == http.StatusTooManyRequests {
+		return true
 	}
-	if err := waitForRetry(ctx, retryDelay(header.Get("Retry-After"), attempt)); err != nil {
-		return false, err
+	if statusCode >= http.StatusBadRequest {
+		return bodyHasErrorCode(body, "RATELIMITED")
 	}
 
-	return true, nil
+	return false
+}
+
+// bodyHasErrorCode reports whether a GraphQL response body carries an error
+// with the given extensions.code value.
+func bodyHasErrorCode(body []byte, code string) bool {
+	var payload struct {
+		Errors []struct {
+			Extensions struct {
+				Code string `json:"code"`
+			} `json:"extensions"`
+		} `json:"errors"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return false
+	}
+	for _, graphqlError := range payload.Errors {
+		if graphqlError.Extensions.Code == code {
+			return true
+		}
+	}
+
+	return false
+}
+
+// rateLimitError wraps ErrRateLimited with the terminal status and body so
+// callers can detect quota exhaustion with errors.Is.
+func rateLimitError(statusCode int, body []byte) error {
+	return fmt.Errorf("%w: graphql http status %d: %s", ErrRateLimited, statusCode, strings.TrimSpace(string(body)))
 }
 
 func decodeGraphQLResponse(body []byte, statusCode int, response *graphql.Response) error {
@@ -174,7 +206,7 @@ func (transport *Transport) send(ctx context.Context, payload []byte) ([]byte, i
 	if err != nil {
 		return nil, 0, nil, fmt.Errorf("request failed: %w", err)
 	}
-	body, readErr := io.ReadAll(httpResponse.Body)
+	body, readErr := io.ReadAll(io.LimitReader(httpResponse.Body, maxResponseBytes))
 	closeErr := httpResponse.Body.Close()
 	if readErr != nil {
 		return nil, 0, nil, fmt.Errorf("read response body: %w", readErr)
@@ -186,15 +218,31 @@ func (transport *Transport) send(ctx context.Context, payload []byte) ([]byte, i
 	return body, httpResponse.StatusCode, httpResponse.Header, nil
 }
 
-func retryDelay(retryAfter string, attempt int) time.Duration {
-	if retryAfter != "" {
+// maxRetryDelay caps how long a single retry waits, so a hostile or
+// misconfigured Retry-After header cannot block the process indefinitely.
+const maxRetryDelay = 30 * time.Second
+
+// maxResponseBytes bounds how much of a response body is buffered, as
+// defense-in-depth against a misconfigured or hostile endpoint.
+const maxResponseBytes = 16 << 20
+
+func retryDelay(header http.Header, attempt int) time.Duration {
+	if retryAfter := header.Get("Retry-After"); retryAfter != "" {
 		seconds, err := strconv.Atoi(retryAfter)
 		if err == nil {
-			return time.Duration(seconds) * time.Second
+			return capRetryDelay(time.Duration(seconds) * time.Second)
 		}
 	}
 
 	return time.Duration(attempt+1) * 100 * time.Millisecond
+}
+
+func capRetryDelay(delay time.Duration) time.Duration {
+	if delay > maxRetryDelay {
+		return maxRetryDelay
+	}
+
+	return delay
 }
 
 func waitForRetry(ctx context.Context, delay time.Duration) error {

--- a/internal/client/transport.go
+++ b/internal/client/transport.go
@@ -135,7 +135,7 @@ func isRateLimited(statusCode int, body []byte) bool {
 	if statusCode == http.StatusTooManyRequests {
 		return true
 	}
-	if statusCode >= http.StatusBadRequest {
+	if statusCode == http.StatusBadRequest {
 		return bodyHasErrorCode(body, "RATELIMITED")
 	}
 
@@ -218,8 +218,9 @@ func (transport *Transport) send(ctx context.Context, payload []byte) ([]byte, i
 	return body, httpResponse.StatusCode, httpResponse.Header, nil
 }
 
-// maxRetryDelay caps how long a single retry waits, so a hostile or
-// misconfigured Retry-After header cannot block the process indefinitely.
+// maxRetryDelay caps how long a single retry waits, so neither a hostile or
+// misconfigured Retry-After header nor a large MaxRetries can block the
+// process indefinitely.
 const maxRetryDelay = 30 * time.Second
 
 // maxResponseBytes bounds how much of a response body is buffered, as
@@ -230,19 +231,11 @@ func retryDelay(header http.Header, attempt int) time.Duration {
 	if retryAfter := header.Get("Retry-After"); retryAfter != "" {
 		seconds, err := strconv.Atoi(retryAfter)
 		if err == nil {
-			return capRetryDelay(time.Duration(seconds) * time.Second)
+			return min(time.Duration(seconds)*time.Second, maxRetryDelay)
 		}
 	}
 
-	return time.Duration(attempt+1) * 100 * time.Millisecond
-}
-
-func capRetryDelay(delay time.Duration) time.Duration {
-	if delay > maxRetryDelay {
-		return maxRetryDelay
-	}
-
-	return delay
+	return min(time.Duration(attempt+1)*100*time.Millisecond, maxRetryDelay)
 }
 
 func waitForRetry(ctx context.Context, delay time.Duration) error {

--- a/internal/client/transport_test.go
+++ b/internal/client/transport_test.go
@@ -173,10 +173,19 @@ func Test_Transport_returns_rate_limited_error_after_exhausting_retries(t *testi
 
 func Test_Transport_returns_error_when_context_timeout_expires(t *testing.T) {
 	// Given
+	release := make(chan struct{})
 	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, request *http.Request) {
-		<-request.Context().Done()
+		// Hold the response open so the nanosecond client timeout is what fails
+		// the request. Also release on cleanup: Windows does not reliably cancel
+		// the server-side request context when the client disconnects, which
+		// would otherwise hang server.Close until the test deadline.
+		select {
+		case <-request.Context().Done():
+		case <-release:
+		}
 	}))
 	defer server.Close()
+	defer close(release)
 	transport := NewTransport(TransportConfig{
 		Endpoint: server.URL,
 		Token:    PersonalAPIToken("test-token"),

--- a/internal/client/transport_test.go
+++ b/internal/client/transport_test.go
@@ -94,6 +94,83 @@ func Test_Transport_retries_429_with_retry_after_when_present(t *testing.T) {
 	require.NotContains(t, logs.String(), "user-id")
 }
 
+func Test_Transport_retries_ratelimited_400_then_succeeds(t *testing.T) {
+	// Given Linear signals a rate limit with HTTP 400 + RATELIMITED, not 429.
+	logs := bytes.Buffer{}
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		requests++
+		writer.Header().Set("Content-Type", "application/json")
+		if requests == 1 {
+			writer.WriteHeader(http.StatusBadRequest)
+			_, err := writer.Write([]byte(`{"errors":[{"message":"rate limit exceeded","extensions":{"code":"RATELIMITED"}}]}`))
+			if err != nil {
+				t.Errorf("write response: %v", err)
+			}
+			return
+		}
+		_, err := writer.Write([]byte(`{"data":{"viewer":{"id":"user-id"}}}`))
+		if err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	defer server.Close()
+	transport := NewTransport(TransportConfig{
+		DiagnosticWriter: &logs,
+		Endpoint:         server.URL,
+		Token:            PersonalAPIToken("test-token"),
+		Timeout:          2 * time.Second,
+		MaxRetries:       1,
+	})
+	response := graphql.Response{Data: &testGraphQLData{}}
+
+	// When
+	err := transport.MakeRequest(context.Background(), &graphql.Request{Query: "query Test { viewer { id } }"}, &response)
+
+	// Then
+	require.NoError(t, err)
+	require.Equal(t, 2, requests)
+	data, ok := response.Data.(*testGraphQLData)
+	require.True(t, ok)
+	require.Equal(t, "user-id", data.Viewer.ID)
+	require.Contains(t, logs.String(), "graphql_retry attempt=1 status=400")
+	require.Contains(t, logs.String(), "graphql_request_ok attempt=2 status=200")
+}
+
+func Test_Transport_returns_rate_limited_error_after_exhausting_retries(t *testing.T) {
+	// Given a server that always returns the RATELIMITED 400.
+	logs := bytes.Buffer{}
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		requests++
+		writer.Header().Set("Content-Type", "application/json")
+		writer.WriteHeader(http.StatusBadRequest)
+		_, err := writer.Write([]byte(`{"errors":[{"message":"rate limit exceeded","extensions":{"code":"RATELIMITED"}}]}`))
+		if err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	defer server.Close()
+	transport := NewTransport(TransportConfig{
+		DiagnosticWriter: &logs,
+		Endpoint:         server.URL,
+		Token:            PersonalAPIToken("test-token"),
+		Timeout:          2 * time.Second,
+		MaxRetries:       1,
+	})
+	response := graphql.Response{Data: &testGraphQLData{}}
+
+	// When
+	err := transport.MakeRequest(context.Background(), &graphql.Request{Query: "query Test { viewer { id } }"}, &response)
+
+	// Then
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrRateLimited)
+	require.Equal(t, 2, requests)
+	require.Contains(t, logs.String(), "graphql_rate_limited attempt=2 status=400")
+	require.NotContains(t, logs.String(), "test-token")
+}
+
 func Test_Transport_returns_error_when_context_timeout_expires(t *testing.T) {
 	// Given
 	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, request *http.Request) {

--- a/internal/client/write_guard_fuzz_test.go
+++ b/internal/client/write_guard_fuzz_test.go
@@ -1,0 +1,56 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/KyaniteHQ/linctl/internal/config"
+)
+
+// FuzzRequireTargetMatch is the property form of the fail-closed invariant from
+// ADR-0001: requireTargetMatch must accept a resolved target only when its
+// org, team id, and team key all equal the pinned target, and otherwise refuse
+// with ErrTargetMismatch. The example-based guard tests cover specific
+// scenarios; this proves the invariant across the whole input space.
+func FuzzRequireTargetMatch(f *testing.F) {
+	seeds := []struct {
+		expectedOrg, expectedTeamID, expectedTeamKey string
+		resolvedOrg, resolvedTeamID, resolvedTeamKey string
+	}{
+		{"org", "team", "LIT", "org", "team", "LIT"},
+		{"org", "team", "LIT", "other", "team", "LIT"},
+		{"org", "team", "LIT", "org", "other", "LIT"},
+		{"org", "team", "LIT", "org", "team", "OTHER"},
+		{"", "", "", "", "", ""},
+		{"o", "t", "k", "", "", ""},
+	}
+	for _, seed := range seeds {
+		f.Add(
+			seed.expectedOrg, seed.expectedTeamID, seed.expectedTeamKey,
+			seed.resolvedOrg, seed.resolvedTeamID, seed.resolvedTeamKey,
+		)
+	}
+
+	f.Fuzz(func(
+		t *testing.T,
+		expectedOrg, expectedTeamID, expectedTeamKey string,
+		resolvedOrg, resolvedTeamID, resolvedTeamKey string,
+	) {
+		expected := config.Target{OrgID: expectedOrg, TeamID: expectedTeamID, TeamKey: expectedTeamKey}
+		resolved := config.Target{OrgID: resolvedOrg, TeamID: resolvedTeamID, TeamKey: resolvedTeamKey}
+
+		err := requireTargetMatch(expected, resolved)
+
+		matches := resolvedOrg == expectedOrg &&
+			resolvedTeamID == expectedTeamID &&
+			resolvedTeamKey == expectedTeamKey
+		if matches {
+			require.NoError(t, err)
+
+			return
+		}
+
+		require.ErrorIs(t, err, ErrTargetMismatch)
+	})
+}

--- a/internal/gitctx/branch_fuzz_test.go
+++ b/internal/gitctx/branch_fuzz_test.go
@@ -1,0 +1,50 @@
+package gitctx
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// FuzzParseIssueIdentifier asserts the parser never panics and that any
+// identifier it returns is a real, well-formed substring of the input that
+// re-parses to itself.
+func FuzzParseIssueIdentifier(f *testing.F) {
+	seeds := []string{
+		"",
+		"LIT-123",
+		"feature/LIT-42-add-thing",
+		"no issue reference here",
+		"lit-99",
+		"ABC-1 DEF-2",
+		"LIT-",
+		"-5",
+		"A1-2",
+		"Ω-3",
+		"LIT-123-456",
+		"\n\tLIT-7\n",
+	}
+	for _, seed := range seeds {
+		f.Add(seed)
+	}
+
+	wellFormed := regexp.MustCompile(`^[A-Z][A-Z0-9]+-[0-9]+$`)
+
+	f.Fuzz(func(t *testing.T, text string) {
+		identifier, ok := ParseIssueIdentifier(text)
+		if !ok {
+			require.Empty(t, identifier)
+
+			return
+		}
+
+		require.NotEmpty(t, identifier)
+		require.Contains(t, text, identifier)
+		require.Regexp(t, wellFormed, identifier)
+
+		again, againOK := ParseIssueIdentifier(identifier)
+		require.True(t, againOK)
+		require.Equal(t, identifier, again)
+	})
+}

--- a/internal/gitctx/coverage_test.go
+++ b/internal/gitctx/coverage_test.go
@@ -4,12 +4,17 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
 func Test_GitContextScenarios_resolve_or_report_issue_references(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fakes git/jj via POSIX shell scripts on PATH; not portable to Windows")
+	}
+
 	t.Run("non git directory returns current branch error", func(t *testing.T) {
 		_, err := CurrentIssueIdentifier(context.Background(), t.TempDir())
 

--- a/scripts/go-packages.sh
+++ b/scripts/go-packages.sh
@@ -3,9 +3,14 @@ set -euo pipefail
 
 module_root="$(pwd -P)"
 
-mapfile -t package_dirs < <(
-  find ./cmd ./internal ./scripts -type f -name '*.go' -print |
-    xargs -r -n1 dirname |
+# Collect the unique directories that hold Go files. This avoids the bash 4
+# builtin 'mapfile' and the GNU-only 'xargs -r', so the helper also runs on the
+# macOS system bash (3.2) and BSD userland, not just Linux.
+package_dirs=()
+while IFS= read -r dir; do
+  package_dirs+=("$dir")
+done < <(
+  find ./cmd ./internal ./scripts -type f -name '*.go' -exec dirname {} \; |
     sort -u
 )
 


### PR DESCRIPTION
Pre-go-live hardening pass. Every commit is gated by `task ci` (generate-drift, vet, race tests, build, lint, govulncheck) and `task coverage` (100% hand-written statement coverage), and the whole branch is verified green on **Linux, macOS, and Windows**.

## What's in
1. **CI/release hardening** — split + harden the CI/release workflows, SHA-pin every action, add dependabot, tighten gates, and add a cross-OS test + build + `--version`/`--help` smoke matrix.
2. **Rate-limit detection fix** — Linear signals the per-key quota with HTTP 400 + a `RATELIMITED` GraphQL code, but the transport only retried on 429, so the retry/backoff path was dead. Detect it correctly (scoped to HTTP 400), cap every retry delay at 30s, and bound the response read at 16 MiB.
3. **`--json --fields` fix** — projection for `favorite`/`emoji`/`attachment` list envelopes (keys were missing from the dispatch table).
4. **Cross-platform fixes** — portable `go-packages.sh` (macOS bash 3.2 / BSD userland), Windows-safe config-path test, and a Windows transport-test hang fixed + a `-timeout 180s` CI guard so a future hang fails fast.
5. **`--debug` observability** — stdlib `log/slog` diagnostics on stderr (text, or JSON via `LINCTL_DEBUG_JSON=1`); the transport's previously-unwired diagnostics now surface under `--debug`; target resolution + **Target Mismatch** logged at the resolve choke point.
6. **Fuzz tests** — the gitctx identifier parser, the `--fields`/`--sort` parsers, and a property form of the ADR-0001 write-guard fail-closed invariant (each fuzzed clean).

## Safety invariants (unchanged)
- The write-guard fail-closed path (`write_guard.go`, `target.go`, `issue_write.go`) is untouched — no bypass flags, no relaxation.
- The genqlient generate-drift gate is intact.

## Verification
- Green on ubuntu / macos / windows; 100% hand-written coverage; golangci-lint v2.12.2; govulncheck; generate-drift; goreleaser snapshot (all 6 os/arch targets build clean).
- Reviewed via `/code-review` (6 finder angles) + `/simplify`; findings applied (rate-limit scoping to HTTP 400, uniform retry-delay cap, `min()` cleanup); token-safety and stdout-hygiene checks came back clean.
