### PR TITLE
Route the issue command surface through a typed Command Port

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -36,6 +36,10 @@ _Avoid_: Unscoped create, workspace write
 A guarded write against an existing Linear entity. It resolves the entity first and compares the pinned project when a project is configured.
 _Avoid_: Direct update, blind write
 
+**Command Port**:
+The narrow, domain-typed interface a Read Command or Guarded Write depends on to reach Linear, decoupled from the GraphQL transport. A command port is defined by its consumer, returns domain summaries rather than GraphQL responses, and is satisfied in production by a thin adapter over the client and in tests by an in-memory fake. It makes the command's interface the test surface.
+_Avoid_: client, gateway, service, mock
+
 **Current Issue**:
 The Linear issue referenced by the current checkout context. It comes from an issue identifier in the branch name or checkout metadata.
 _Avoid_: Active ticket, selected issue

--- a/internal/cli/command_flow_runtime_errors_test.go
+++ b/internal/cli/command_flow_runtime_errors_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"strings"
@@ -10,7 +11,68 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/KyaniteHQ/linctl/internal/client"
+	"github.com/KyaniteHQ/linctl/internal/config"
 )
+
+func Test_CommandFlows_emit_guarded_write_target_error_codes(t *testing.T) {
+	tests := []struct {
+		name        string
+		target      config.Target
+		wantErr     error
+		wantCode    string
+		wantMessage string
+	}{
+		{
+			name:        "missing pinned target",
+			target:      config.Target{},
+			wantErr:     client.ErrTargetNotConfigured,
+			wantCode:    `"error_code":"TARGET_NOT_CONFIGURED"`,
+			wantMessage: "set org_id, team_key, and team_id in .linctl.toml",
+		},
+		{
+			name: "resolved target mismatch",
+			target: config.Target{
+				OrgID:     "other-org",
+				TeamKey:   "LIT",
+				TeamID:    "team-id",
+				ProjectID: "project-id",
+			},
+			wantErr:     client.ErrTargetMismatch,
+			wantCode:    `"error_code":"TARGET_MISMATCH"`,
+			wantMessage: "expected team_id=team-id team_key=LIT",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			original := buildCommandRuntime
+			buildCommandRuntime = func(_ context.Context, _ *rootOptions) (commandRuntime, error) {
+				runtime := testCommandRuntime(commandFlowFakeClient{})
+				runtime.config.Target = test.target
+				return runtime, nil
+			}
+			defer func() {
+				buildCommandRuntime = original
+			}()
+
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+
+			err := execute(
+				context.Background(),
+				BuildInfo{},
+				strings.NewReader(""),
+				&stdout,
+				&stderr,
+				[]string{"issue", "create", "--title", "Created issue"},
+			)
+
+			require.ErrorIs(t, err, test.wantErr)
+			require.Empty(t, stdout.String())
+			require.Contains(t, stderr.String(), test.wantCode)
+			require.Contains(t, stderr.String(), test.wantMessage)
+		})
+	}
+}
 
 func Test_CommandFlows_report_runtime_and_writer_errors(t *testing.T) {
 	t.Run("runtime error returns from command", func(t *testing.T) {

--- a/internal/cli/issue.go
+++ b/internal/cli/issue.go
@@ -108,22 +108,8 @@ func addIssueListCommand(ctx context.Context, root *cobra.Command, options *root
 			if err != nil {
 				return err
 			}
-			issues, err := issueList(ctx, runtime, limit, flags)
-			if err != nil {
-				return err
-			}
-			if err := ensureNonEmpty(options, len(issues.Issues)); err != nil {
-				return err
-			}
-			issues.Issues, err = sortByJSONField(issues.Issues, options.sortField, options.sortOrder)
-			if err != nil {
-				return err
-			}
-			if options.json {
-				return writeJSONValue(command, options, issues)
-			}
 
-			return writeIssues(command, options, issues.Issues)
+			return runIssueList(ctx, command, options, issueAdapterFor(runtime), limit, flags)
 		},
 	}
 	bindIssueListFlags(
@@ -234,22 +220,48 @@ func validateIssueListFilters(flags issueListFlagValues) error {
 	return nil
 }
 
+func runIssueList(
+	ctx context.Context,
+	command *cobra.Command,
+	options *rootOptions,
+	reader issueReader,
+	limit int,
+	flags issueListFlagValues,
+) error {
+	issues, err := issueList(ctx, reader, limit, flags)
+	if err != nil {
+		return err
+	}
+	if err := ensureNonEmpty(options, len(issues.Issues)); err != nil {
+		return err
+	}
+	issues.Issues, err = sortByJSONField(issues.Issues, options.sortField, options.sortOrder)
+	if err != nil {
+		return err
+	}
+	if options.json {
+		return writeJSONValue(command, options, issues)
+	}
+
+	return writeIssues(command, options, issues.Issues)
+}
+
 func issueList(
 	ctx context.Context,
-	runtime commandRuntime,
+	reader issueReader,
 	limit int,
 	flags issueListFlagValues,
 ) (client.IssueList, error) {
 	if flags.allTeams {
-		return client.ListIssues(ctx, runtime.graphqlClient, limit)
+		return reader.ListIssues(ctx, limit)
 	}
 
-	target, err := runtime.resolveTarget(ctx)
+	target, err := reader.ResolveTarget(ctx)
 	if err != nil {
 		return client.IssueList{}, err
 	}
 
-	return client.ListIssuesByTeam(ctx, runtime.graphqlClient, target.Team.ID, limit,
+	return reader.ListIssuesByTeam(ctx, target.Team.ID, limit,
 		client.IssueListFilters{
 			StateType:     flags.stateType,
 			ProjectID:     flags.projectID,
@@ -439,7 +451,7 @@ func addIssueGetCommand(ctx context.Context, root *cobra.Command, options *rootO
 			if err != nil {
 				return err
 			}
-			issue, err := client.GetIssueByID(ctx, runtime.graphqlClient, args[0])
+			issue, err := issueAdapterFor(runtime).GetIssueByID(ctx, args[0])
 			if err != nil {
 				return err
 			}

--- a/internal/cli/issue_deps.go
+++ b/internal/cli/issue_deps.go
@@ -20,7 +20,7 @@ func addIssueDepsCommand(ctx context.Context, root *cobra.Command, options *root
 			if err != nil {
 				return err
 			}
-			dependencies, err := client.GetIssueDependencies(ctx, runtime.graphqlClient, args[0], limit)
+			dependencies, err := issueAdapterFor(runtime).GetIssueDependencies(ctx, args[0], limit)
 			if err != nil {
 				return err
 			}

--- a/internal/cli/issue_port.go
+++ b/internal/cli/issue_port.go
@@ -43,6 +43,20 @@ type issueCommenter interface {
 	CommentOnIssue(ctx context.Context, request client.IssueCommentRequest) (client.IssueCommentResult, error)
 }
 
+// issueReader is the port the issue list command depends on for its dispatch:
+// it either lists across teams or resolves the pinned team and lists with the
+// assembled filters.
+type issueReader interface {
+	ResolveTarget(ctx context.Context) (client.ResolvedTarget, error)
+	ListIssues(ctx context.Context, limit int) (client.IssueList, error)
+	ListIssuesByTeam(
+		ctx context.Context,
+		teamID string,
+		limit int,
+		filters client.IssueListFilters,
+	) (client.IssueList, error)
+}
+
 // issueClientAdapter satisfies the issue command ports by forwarding to the
 // client package's guarded free functions with the runtime's transport and
 // pinned target. It is a pass-through adapter: large surface, trivial body.
@@ -108,4 +122,33 @@ func (adapter issueClientAdapter) CreateIssueRelation(
 
 func (adapter issueClientAdapter) DeleteIssueRelation(ctx context.Context, relationID string) (string, error) {
 	return client.DeleteIssueRelation(ctx, adapter.graphqlClient, adapter.target, relationID)
+}
+
+func (adapter issueClientAdapter) ResolveTarget(ctx context.Context) (client.ResolvedTarget, error) {
+	return client.ResolveTarget(ctx, adapter.graphqlClient, adapter.target)
+}
+
+func (adapter issueClientAdapter) ListIssues(ctx context.Context, limit int) (client.IssueList, error) {
+	return client.ListIssues(ctx, adapter.graphqlClient, limit)
+}
+
+func (adapter issueClientAdapter) ListIssuesByTeam(
+	ctx context.Context,
+	teamID string,
+	limit int,
+	filters client.IssueListFilters,
+) (client.IssueList, error) {
+	return client.ListIssuesByTeam(ctx, adapter.graphqlClient, teamID, limit, filters)
+}
+
+func (adapter issueClientAdapter) GetIssueByID(ctx context.Context, issueID string) (client.IssueSummary, error) {
+	return client.GetIssueByID(ctx, adapter.graphqlClient, issueID)
+}
+
+func (adapter issueClientAdapter) GetIssueDependencies(
+	ctx context.Context,
+	issueID string,
+	limit int,
+) (client.IssueDependencyGraph, error) {
+	return client.GetIssueDependencies(ctx, adapter.graphqlClient, issueID, limit)
 }

--- a/internal/cli/issue_port.go
+++ b/internal/cli/issue_port.go
@@ -1,0 +1,65 @@
+package cli
+
+import (
+	"context"
+
+	"github.com/Khan/genqlient/graphql"
+
+	"github.com/KyaniteHQ/linctl/internal/client"
+	"github.com/KyaniteHQ/linctl/internal/config"
+)
+
+// The Command Port is the narrow, domain-typed interface an issue command depends
+// on to reach Linear, decoupled from the GraphQL transport. Each interface is
+// defined by its consumer and returns domain summaries rather than GraphQL
+// responses, so command logic is tested through it without canned transport
+// payloads. issueClientAdapter is the production adapter over the client package;
+// tests supply an in-memory fake. The guarded-write comparison stays in
+// internal/client — the adapter only forwards.
+
+// issueTemplateReader reads a Linear template's issue defaults (a free read).
+type issueTemplateReader interface {
+	GetIssueTemplateContent(ctx context.Context, templateID string) (client.IssueTemplateContent, error)
+}
+
+// issueCreator is the port the issue create command depends on.
+type issueCreator interface {
+	issueTemplateReader
+	CreateIssue(ctx context.Context, request client.IssueCreateRequest) (client.IssueSummary, error)
+}
+
+// issueCloser is the port the issue close command depends on.
+type issueCloser interface {
+	CloseIssue(ctx context.Context, issueID string) (client.IssueSummary, error)
+}
+
+// issueClientAdapter satisfies the issue command ports by forwarding to the
+// client package's guarded free functions with the runtime's transport and
+// pinned target. It is a pass-through adapter: large surface, trivial body.
+type issueClientAdapter struct {
+	graphqlClient graphql.Client
+	target        config.Target
+}
+
+// issueAdapterFor builds the production issue port from a resolved runtime.
+func issueAdapterFor(runtime commandRuntime) issueClientAdapter {
+	return issueClientAdapter{graphqlClient: runtime.graphqlClient, target: runtime.config.Target}
+}
+
+func (adapter issueClientAdapter) CreateIssue(
+	ctx context.Context,
+	request client.IssueCreateRequest,
+) (client.IssueSummary, error) {
+	return client.CreateIssue(ctx, adapter.graphqlClient, adapter.target, request)
+}
+
+func (adapter issueClientAdapter) CloseIssue(ctx context.Context, issueID string) (client.IssueSummary, error) {
+	return client.CloseIssue(ctx, adapter.graphqlClient, adapter.target, issueID)
+}
+
+func (adapter issueClientAdapter) GetIssueTemplateContent(
+	ctx context.Context,
+	templateID string,
+) (client.IssueTemplateContent, error) {
+	return client.GetIssueTemplateContent(ctx, adapter.graphqlClient, templateID)
+}

--- a/internal/cli/issue_port.go
+++ b/internal/cli/issue_port.go
@@ -33,6 +33,16 @@ type issueCloser interface {
 	CloseIssue(ctx context.Context, issueID string) (client.IssueSummary, error)
 }
 
+// issueUpdater is the port the issue update command depends on.
+type issueUpdater interface {
+	UpdateIssue(ctx context.Context, request client.IssueUpdateRequest) (client.IssueSummary, error)
+}
+
+// issueCommenter is the port the issue comment and reply commands depend on.
+type issueCommenter interface {
+	CommentOnIssue(ctx context.Context, request client.IssueCommentRequest) (client.IssueCommentResult, error)
+}
+
 // issueClientAdapter satisfies the issue command ports by forwarding to the
 // client package's guarded free functions with the runtime's transport and
 // pinned target. It is a pass-through adapter: large surface, trivial body.
@@ -62,4 +72,40 @@ func (adapter issueClientAdapter) GetIssueTemplateContent(
 	templateID string,
 ) (client.IssueTemplateContent, error) {
 	return client.GetIssueTemplateContent(ctx, adapter.graphqlClient, templateID)
+}
+
+func (adapter issueClientAdapter) UpdateIssue(
+	ctx context.Context,
+	request client.IssueUpdateRequest,
+) (client.IssueSummary, error) {
+	return client.UpdateIssue(ctx, adapter.graphqlClient, adapter.target, request)
+}
+
+func (adapter issueClientAdapter) CommentOnIssue(
+	ctx context.Context,
+	request client.IssueCommentRequest,
+) (client.IssueCommentResult, error) {
+	return client.CommentOnIssue(ctx, adapter.graphqlClient, adapter.target, request)
+}
+
+func (adapter issueClientAdapter) StartIssue(ctx context.Context, issueID string) (client.IssueSummary, error) {
+	return client.StartIssue(ctx, adapter.graphqlClient, adapter.target, issueID)
+}
+
+func (adapter issueClientAdapter) LinkIssueAttachment(
+	ctx context.Context,
+	request client.AttachmentLinkRequest,
+) (client.AttachmentSummary, error) {
+	return client.LinkIssueAttachment(ctx, adapter.graphqlClient, adapter.target, request)
+}
+
+func (adapter issueClientAdapter) CreateIssueRelation(
+	ctx context.Context,
+	request client.IssueRelationCreateRequest,
+) (client.IssueRelationSummary, error) {
+	return client.CreateIssueRelation(ctx, adapter.graphqlClient, adapter.target, request)
+}
+
+func (adapter issueClientAdapter) DeleteIssueRelation(ctx context.Context, relationID string) (string, error) {
+	return client.DeleteIssueRelation(ctx, adapter.graphqlClient, adapter.target, relationID)
 }

--- a/internal/cli/issue_port_test.go
+++ b/internal/cli/issue_port_test.go
@@ -24,6 +24,32 @@ type fakeIssuePort struct {
 	closeCalls  int
 	template    client.IssueTemplateContent
 	templateErr error
+	updated     client.IssueSummary
+	updateReq   client.IssueUpdateRequest
+	updateCalls int
+	updateErr   error
+	commented   client.IssueCommentResult
+	commentReq  client.IssueCommentRequest
+	commentErr  error
+}
+
+func (port *fakeIssuePort) UpdateIssue(
+	_ context.Context,
+	request client.IssueUpdateRequest,
+) (client.IssueSummary, error) {
+	port.updateCalls++
+	port.updateReq = request
+
+	return port.updated, port.updateErr
+}
+
+func (port *fakeIssuePort) CommentOnIssue(
+	_ context.Context,
+	request client.IssueCommentRequest,
+) (client.IssueCommentResult, error) {
+	port.commentReq = request
+
+	return port.commented, port.commentErr
 }
 
 func (port *fakeIssuePort) CreateIssue(
@@ -162,6 +188,89 @@ func Test_runIssueClose_calls_the_port_and_renders(t *testing.T) {
 	require.Contains(t, stdout.String(), "LIT-3")
 }
 
+func Test_runIssueUpdate_assembles_request_through_the_port(t *testing.T) {
+	command, stdout, stderr := bufferedCommand()
+	port := &fakeIssuePort{
+		updated: client.IssueSummary{ID: "u-id", Identifier: "LIT-1", Title: "Renamed", State: "Done"},
+	}
+	estimate := 8
+
+	err := runIssueUpdate(
+		context.Background(),
+		command,
+		&rootOptions{},
+		port,
+		client.IssueUpdateRequest{ID: "LIT-1", Title: "Renamed"},
+		issueUpdateFlags{state: "done", priority: "urgent"},
+		&estimate,
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, 1, port.updateCalls)
+	require.Equal(t, "LIT-1", port.updateReq.ID)
+	require.Equal(t, "completed", port.updateReq.StateType)
+	require.Equal(t, "1", port.updateReq.Priority)
+	require.NotNil(t, port.updateReq.Estimate)
+	require.Equal(t, 8, *port.updateReq.Estimate)
+	require.Contains(t, stderr.String(), "normalized")
+	require.Contains(t, stdout.String(), "LIT-1")
+}
+
+func Test_runIssueUpdate_propagates_port_error(t *testing.T) {
+	command, _, _ := bufferedCommand()
+	port := &fakeIssuePort{updateErr: errors.New("update failed")}
+
+	err := runIssueUpdate(
+		context.Background(),
+		command,
+		&rootOptions{},
+		port,
+		client.IssueUpdateRequest{ID: "LIT-1"},
+		issueUpdateFlags{},
+		nil,
+	)
+
+	require.ErrorContains(t, err, "update failed")
+	require.Equal(t, 1, port.updateCalls)
+}
+
+func Test_runIssueBodyWriteCommand_comments_through_the_port(t *testing.T) {
+	command, stdout, _ := bufferedCommand()
+	port := &fakeIssuePort{
+		commented: client.IssueCommentResult{ID: "cmt-1", Issue: client.IssueSummary{Identifier: "LIT-1"}},
+	}
+
+	err := runIssueBodyWriteCommand(
+		context.Background(),
+		command,
+		&rootOptions{},
+		port,
+		client.IssueCommentRequest{ID: "LIT-1", Body: "looks good"},
+		"",
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, "looks good", port.commentReq.Body)
+	require.Equal(t, "LIT-1", port.commentReq.ID)
+	require.Contains(t, stdout.String(), "comment cmt-1 on LIT-1")
+}
+
+func Test_runIssueBodyWriteCommand_propagates_port_error(t *testing.T) {
+	command, _, _ := bufferedCommand()
+	port := &fakeIssuePort{commentErr: errors.New("comment failed")}
+
+	err := runIssueBodyWriteCommand(
+		context.Background(),
+		command,
+		&rootOptions{},
+		port,
+		client.IssueCommentRequest{ID: "LIT-1", Body: "x"},
+		"",
+	)
+
+	require.ErrorContains(t, err, "comment failed")
+}
+
 // Test_issueClientAdapter_forwards_to_client proves the production adapter wires
 // each port method to the right client free function. The canned GraphQL JSON is
 // confined here, at the adapter seam, rather than smeared across command tests.
@@ -179,4 +288,12 @@ func Test_issueClientAdapter_forwards_to_client(t *testing.T) {
 
 	_, err = adapter.GetIssueTemplateContent(ctx, "tmpl-1")
 	require.NoError(t, err)
+
+	updated, err := adapter.UpdateIssue(ctx, client.IssueUpdateRequest{ID: "LIT-1", Title: "Renamed"})
+	require.NoError(t, err)
+	require.NotEmpty(t, updated.ID)
+
+	comment, err := adapter.CommentOnIssue(ctx, client.IssueCommentRequest{ID: "LIT-1", Body: "note"})
+	require.NoError(t, err)
+	require.NotEmpty(t, comment.ID)
 }

--- a/internal/cli/issue_port_test.go
+++ b/internal/cli/issue_port_test.go
@@ -15,22 +15,53 @@ import (
 // fakeIssuePort is an in-memory Command Port: it returns domain summaries
 // directly, so issue command logic is tested without canned GraphQL JSON.
 type fakeIssuePort struct {
-	created     client.IssueSummary
-	createReq   client.IssueCreateRequest
-	createCalls int
-	createErr   error
-	closed      client.IssueSummary
-	closeID     string
-	closeCalls  int
-	template    client.IssueTemplateContent
-	templateErr error
-	updated     client.IssueSummary
-	updateReq   client.IssueUpdateRequest
-	updateCalls int
-	updateErr   error
-	commented   client.IssueCommentResult
-	commentReq  client.IssueCommentRequest
-	commentErr  error
+	created       client.IssueSummary
+	createReq     client.IssueCreateRequest
+	createCalls   int
+	createErr     error
+	closed        client.IssueSummary
+	closeID       string
+	closeCalls    int
+	template      client.IssueTemplateContent
+	templateErr   error
+	updated       client.IssueSummary
+	updateReq     client.IssueUpdateRequest
+	updateCalls   int
+	updateErr     error
+	commented     client.IssueCommentResult
+	commentReq    client.IssueCommentRequest
+	commentErr    error
+	resolved      client.ResolvedTarget
+	resolveErr    error
+	listAll       client.IssueList
+	listAllCalls  int
+	listTeam      client.IssueList
+	listTeamID    string
+	listFilters   client.IssueListFilters
+	listTeamCalls int
+}
+
+func (port *fakeIssuePort) ResolveTarget(_ context.Context) (client.ResolvedTarget, error) {
+	return port.resolved, port.resolveErr
+}
+
+func (port *fakeIssuePort) ListIssues(_ context.Context, _ int) (client.IssueList, error) {
+	port.listAllCalls++
+
+	return port.listAll, nil
+}
+
+func (port *fakeIssuePort) ListIssuesByTeam(
+	_ context.Context,
+	teamID string,
+	_ int,
+	filters client.IssueListFilters,
+) (client.IssueList, error) {
+	port.listTeamCalls++
+	port.listTeamID = teamID
+	port.listFilters = filters
+
+	return port.listTeam, nil
 }
 
 func (port *fakeIssuePort) UpdateIssue(
@@ -271,6 +302,49 @@ func Test_runIssueBodyWriteCommand_propagates_port_error(t *testing.T) {
 	require.ErrorContains(t, err, "comment failed")
 }
 
+func Test_issueList_lists_across_teams_when_all_teams(t *testing.T) {
+	port := &fakeIssuePort{
+		listAll: client.IssueList{Issues: []client.IssueSummary{{Identifier: "LIT-1"}}},
+	}
+
+	list, err := issueList(context.Background(), port, 50, issueListFlagValues{allTeams: true})
+
+	require.NoError(t, err)
+	require.Equal(t, 1, port.listAllCalls)
+	require.Equal(t, 0, port.listTeamCalls)
+	require.Len(t, list.Issues, 1)
+}
+
+func Test_issueList_resolves_team_and_assembles_filters(t *testing.T) {
+	port := &fakeIssuePort{
+		resolved: client.ResolvedTarget{
+			Team:   client.TargetTeam{ID: "team-id"},
+			Viewer: client.TargetViewer{ID: "viewer-id"},
+		},
+		listTeam: client.IssueList{Issues: []client.IssueSummary{{Identifier: "LIT-2"}}},
+	}
+
+	_, err := issueList(context.Background(), port, 50, issueListFlagValues{mine: true, stateType: "started"})
+
+	require.NoError(t, err)
+	require.Equal(t, 1, port.listTeamCalls)
+	require.Equal(t, "team-id", port.listTeamID)
+	require.Equal(t, "viewer-id", port.listFilters.AssigneeID) // --mine resolves to the viewer id
+	require.Equal(t, "started", port.listFilters.StateType)
+}
+
+func Test_runIssueList_renders_issues_through_the_port(t *testing.T) {
+	command, stdout, _ := bufferedCommand()
+	port := &fakeIssuePort{
+		listAll: client.IssueList{Issues: []client.IssueSummary{{Identifier: "LIT-7", Title: "Listed", State: "Todo"}}},
+	}
+
+	err := runIssueList(context.Background(), command, &rootOptions{}, port, 50, issueListFlagValues{allTeams: true})
+
+	require.NoError(t, err)
+	require.Contains(t, stdout.String(), "LIT-7")
+}
+
 // Test_issueClientAdapter_forwards_to_client proves the production adapter wires
 // each port method to the right client free function. The canned GraphQL JSON is
 // confined here, at the adapter seam, rather than smeared across command tests.
@@ -296,4 +370,21 @@ func Test_issueClientAdapter_forwards_to_client(t *testing.T) {
 	comment, err := adapter.CommentOnIssue(ctx, client.IssueCommentRequest{ID: "LIT-1", Body: "note"})
 	require.NoError(t, err)
 	require.NotEmpty(t, comment.ID)
+
+	resolved, err := adapter.ResolveTarget(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, resolved.Team.ID)
+
+	_, err = adapter.ListIssues(ctx, 5)
+	require.NoError(t, err)
+
+	_, err = adapter.ListIssuesByTeam(ctx, resolved.Team.ID, 5, client.IssueListFilters{})
+	require.NoError(t, err)
+
+	got, err := adapter.GetIssueByID(ctx, "LIT-1")
+	require.NoError(t, err)
+	require.NotEmpty(t, got.ID)
+
+	_, err = adapter.GetIssueDependencies(ctx, "LIT-1", 5)
+	require.NoError(t, err)
 }

--- a/internal/cli/issue_port_test.go
+++ b/internal/cli/issue_port_test.go
@@ -1,0 +1,182 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+
+	"github.com/KyaniteHQ/linctl/internal/client"
+)
+
+// fakeIssuePort is an in-memory Command Port: it returns domain summaries
+// directly, so issue command logic is tested without canned GraphQL JSON.
+type fakeIssuePort struct {
+	created     client.IssueSummary
+	createReq   client.IssueCreateRequest
+	createCalls int
+	createErr   error
+	closed      client.IssueSummary
+	closeID     string
+	closeCalls  int
+	template    client.IssueTemplateContent
+	templateErr error
+}
+
+func (port *fakeIssuePort) CreateIssue(
+	_ context.Context,
+	request client.IssueCreateRequest,
+) (client.IssueSummary, error) {
+	port.createCalls++
+	port.createReq = request
+
+	return port.created, port.createErr
+}
+
+func (port *fakeIssuePort) CloseIssue(_ context.Context, issueID string) (client.IssueSummary, error) {
+	port.closeCalls++
+	port.closeID = issueID
+
+	return port.closed, nil
+}
+
+func (port *fakeIssuePort) GetIssueTemplateContent(
+	_ context.Context,
+	_ string,
+) (client.IssueTemplateContent, error) {
+	return port.template, port.templateErr
+}
+
+func bufferedCommand() (*cobra.Command, *bytes.Buffer, *bytes.Buffer) {
+	command := &cobra.Command{}
+	var stdout, stderr bytes.Buffer
+	command.SetOut(&stdout)
+	command.SetErr(&stderr)
+
+	return command, &stdout, &stderr
+}
+
+func Test_runIssueCreate_assembles_request_through_the_port(t *testing.T) {
+	command, stdout, stderr := bufferedCommand()
+	port := &fakeIssuePort{
+		created:  client.IssueSummary{ID: "iss-id", Identifier: "LIT-9", Title: "Created", State: "Todo"},
+		template: client.IssueTemplateContent{Title: "Template title", Description: "Template body"},
+	}
+	estimate := 5
+
+	err := runIssueCreate(
+		context.Background(),
+		command,
+		&rootOptions{},
+		port,
+		client.IssueCreateRequest{}, // empty title/description -> template fills them
+		issueCreateFlags{templateID: "tmpl-1", state: "in progress", priority: "high"},
+		&estimate,
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, 1, port.createCalls)
+	// template defaults filled the empty fields
+	require.Equal(t, "Template title", port.createReq.Title)
+	require.Equal(t, "Template body", port.createReq.Description)
+	// alias normalization reached the port as canonical values
+	require.Equal(t, "started", port.createReq.StateType)
+	require.Equal(t, "2", port.createReq.Priority)
+	// estimate gating forwarded the resolved pointer
+	require.NotNil(t, port.createReq.Estimate)
+	require.Equal(t, 5, *port.createReq.Estimate)
+	// normalization emitted a stderr note, and the issue rendered to stdout
+	require.Contains(t, stderr.String(), "normalized")
+	require.Contains(t, stdout.String(), "LIT-9")
+}
+
+func Test_runIssueCreate_dry_run_never_calls_the_port(t *testing.T) {
+	command, stdout, _ := bufferedCommand()
+	port := &fakeIssuePort{}
+
+	err := runIssueCreate(
+		context.Background(),
+		command,
+		&rootOptions{},
+		port,
+		client.IssueCreateRequest{Title: "Draft only"},
+		issueCreateFlags{dryRun: true},
+		nil,
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, 0, port.createCalls)
+	require.Contains(t, stdout.String(), "Draft only")
+}
+
+func Test_runIssueCreate_propagates_port_error(t *testing.T) {
+	command, _, _ := bufferedCommand()
+	port := &fakeIssuePort{createErr: errors.New("create failed")}
+
+	err := runIssueCreate(
+		context.Background(),
+		command,
+		&rootOptions{},
+		port,
+		client.IssueCreateRequest{Title: "X"},
+		issueCreateFlags{},
+		nil,
+	)
+
+	require.ErrorContains(t, err, "create failed")
+	require.Equal(t, 1, port.createCalls)
+}
+
+func Test_runIssueCreate_propagates_template_error_before_creating(t *testing.T) {
+	command, _, _ := bufferedCommand()
+	port := &fakeIssuePort{templateErr: errors.New("no such template")}
+
+	err := runIssueCreate(
+		context.Background(),
+		command,
+		&rootOptions{},
+		port,
+		client.IssueCreateRequest{Title: "X"},
+		issueCreateFlags{templateID: "missing"},
+		nil,
+	)
+
+	require.ErrorContains(t, err, "no such template")
+	require.Equal(t, 0, port.createCalls)
+}
+
+func Test_runIssueClose_calls_the_port_and_renders(t *testing.T) {
+	command, stdout, _ := bufferedCommand()
+	port := &fakeIssuePort{
+		closed: client.IssueSummary{ID: "c-id", Identifier: "LIT-3", Title: "Done", State: "Done"},
+	}
+
+	err := runIssueClose(context.Background(), command, &rootOptions{}, port, "LIT-3")
+
+	require.NoError(t, err)
+	require.Equal(t, 1, port.closeCalls)
+	require.Equal(t, "LIT-3", port.closeID)
+	require.Contains(t, stdout.String(), "LIT-3")
+}
+
+// Test_issueClientAdapter_forwards_to_client proves the production adapter wires
+// each port method to the right client free function. The canned GraphQL JSON is
+// confined here, at the adapter seam, rather than smeared across command tests.
+func Test_issueClientAdapter_forwards_to_client(t *testing.T) {
+	adapter := issueAdapterFor(testCommandRuntime(commandFlowFakeClient{}))
+	ctx := context.Background()
+
+	created, err := adapter.CreateIssue(ctx, client.IssueCreateRequest{Title: "Created issue"})
+	require.NoError(t, err)
+	require.NotEmpty(t, created.ID)
+
+	closed, err := adapter.CloseIssue(ctx, "LIT-1")
+	require.NoError(t, err)
+	require.NotEmpty(t, closed.ID)
+
+	_, err = adapter.GetIssueTemplateContent(ctx, "tmpl-1")
+	require.NoError(t, err)
+}

--- a/internal/cli/issue_relation_write.go
+++ b/internal/cli/issue_relation_write.go
@@ -19,10 +19,8 @@ func addIssueRelateCommand(ctx context.Context, root *cobra.Command, options *ro
 			if err != nil {
 				return err
 			}
-			relation, err := client.CreateIssueRelation(
+			relation, err := issueAdapterFor(runtime).CreateIssueRelation(
 				ctx,
-				runtime.graphqlClient,
-				runtime.config.Target,
 				client.IssueRelationCreateRequest{
 					IssueID:        args[0],
 					RelatedIssueID: args[1],
@@ -53,7 +51,7 @@ func addIssueUnrelateCommand(ctx context.Context, root *cobra.Command, options *
 			if err != nil {
 				return err
 			}
-			id, err := client.DeleteIssueRelation(ctx, runtime.graphqlClient, runtime.config.Target, args[0])
+			id, err := issueAdapterFor(runtime).DeleteIssueRelation(ctx, args[0])
 			if err != nil {
 				return err
 			}

--- a/internal/cli/issue_template.go
+++ b/internal/cli/issue_template.go
@@ -24,14 +24,14 @@ type issueDraft struct {
 // the template only supplies defaults for fields left empty.
 func applyIssueTemplate(
 	ctx context.Context,
-	runtime commandRuntime,
+	templates issueTemplateReader,
 	request *client.IssueCreateRequest,
 	templateID string,
 ) error {
 	if templateID == "" {
 		return nil
 	}
-	content, err := client.GetIssueTemplateContent(ctx, runtime.graphqlClient, templateID)
+	content, err := templates.GetIssueTemplateContent(ctx, templateID)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/issue_write.go
+++ b/internal/cli/issue_write.go
@@ -103,13 +103,18 @@ func runIssueCreate(
 	return writeIssue(command, options, issue)
 }
 
+// issueUpdateFlags collects the non-request inputs of the issue update command.
+type issueUpdateFlags struct {
+	descriptionFile string
+	appendFile      string
+	state           string
+	status          string
+	priority        string
+}
+
 func addIssueUpdateCommand(ctx context.Context, root *cobra.Command, options *rootOptions) {
 	request := client.IssueUpdateRequest{}
-	descriptionFile := ""
-	appendFile := ""
-	state := ""
-	status := ""
-	priority := ""
+	flags := issueUpdateFlags{}
 	estimate := 0
 	command := &cobra.Command{
 		Use:   "update ISSUE_ID",
@@ -121,37 +126,22 @@ func addIssueUpdateCommand(ctx context.Context, root *cobra.Command, options *ro
 				return err
 			}
 			request.ID = args[0]
-			if err := resolveFileFlag(&request.Description, descriptionFile, "description"); err != nil {
-				return err
-			}
-			if err := resolveFileFlag(&request.Append, appendFile, "append"); err != nil {
-				return err
-			}
-			stateType, normalizedPriority, normErr := applyIssueWriteNormalization(command, state, status, priority)
-			if normErr != nil {
-				return normErr
-			}
-			request.StateType = stateType
-			request.Priority = normalizedPriority
+			var resolvedEstimate *int
 			if command.Flags().Changed("estimate") {
-				request.Estimate = &estimate
-			}
-			issue, err := client.UpdateIssue(ctx, runtime.graphqlClient, runtime.config.Target, request)
-			if err != nil {
-				return err
+				resolvedEstimate = &estimate
 			}
 
-			return writeIssue(command, options, issue)
+			return runIssueUpdate(ctx, command, options, issueAdapterFor(runtime), request, flags, resolvedEstimate)
 		},
 	}
 	command.Flags().StringVar(&request.Title, "title", "", "new issue title")
 	command.Flags().StringVar(&request.Description, "description", "", "new issue description")
-	command.Flags().StringVar(&descriptionFile, "description-file", "", "read new issue description from file")
+	command.Flags().StringVar(&flags.descriptionFile, "description-file", "", "read new issue description from file")
 	command.Flags().StringVar(&request.Append, "append", "", "text to append to the issue description")
-	command.Flags().StringVar(&appendFile, "append-file", "", "read text to append from file")
-	command.Flags().StringVar(&state, "state", "", "set workflow state type (e.g. started, completed)")
-	command.Flags().StringVar(&status, "status", "", "alias for --state")
-	command.Flags().StringVar(&priority, "priority", "", "set priority (urgent/high/medium/low/none or 0-4)")
+	command.Flags().StringVar(&flags.appendFile, "append-file", "", "read text to append from file")
+	command.Flags().StringVar(&flags.state, "state", "", "set workflow state type (e.g. started, completed)")
+	command.Flags().StringVar(&flags.status, "status", "", "alias for --state")
+	command.Flags().StringVar(&flags.priority, "priority", "", "set priority (urgent/high/medium/low/none or 0-4)")
 	command.Flags().StringVar(&request.AssigneeID, "assignee", "", "reassign the issue to a user id")
 	command.Flags().StringArrayVar(&request.LabelIDs, "label", nil, "set labels by id (repeatable, replaces existing)")
 	command.Flags().StringVar(&request.DueDate, "due-date", "", "set the due date (YYYY-MM-DD)")
@@ -160,6 +150,38 @@ func addIssueUpdateCommand(ctx context.Context, root *cobra.Command, options *ro
 	command.Flags().BoolVar(&request.ClearEstimate, "clear-estimate", false, "clear the estimate")
 	registerStateCompletion(ctx, command, options)
 	root.AddCommand(command)
+}
+
+func runIssueUpdate(
+	ctx context.Context,
+	command *cobra.Command,
+	options *rootOptions,
+	updater issueUpdater,
+	request client.IssueUpdateRequest,
+	flags issueUpdateFlags,
+	estimate *int,
+) error {
+	if err := resolveFileFlag(&request.Description, flags.descriptionFile, "description"); err != nil {
+		return err
+	}
+	if err := resolveFileFlag(&request.Append, flags.appendFile, "append"); err != nil {
+		return err
+	}
+	stateType, normalizedPriority, normErr := applyIssueWriteNormalization(
+		command, flags.state, flags.status, flags.priority,
+	)
+	if normErr != nil {
+		return normErr
+	}
+	request.StateType = stateType
+	request.Priority = normalizedPriority
+	request.Estimate = estimate
+	issue, err := updater.UpdateIssue(ctx, request)
+	if err != nil {
+		return err
+	}
+
+	return writeIssue(command, options, issue)
 }
 
 // applyIssueWriteNormalization merges the --state/--status alias pair and
@@ -193,7 +215,7 @@ func addIssueStartCommand(ctx context.Context, root *cobra.Command, options *roo
 			if err != nil {
 				return err
 			}
-			issue, err := client.StartIssue(ctx, runtime.graphqlClient, runtime.config.Target, args[0])
+			issue, err := issueAdapterFor(runtime).StartIssue(ctx, args[0])
 			if err != nil {
 				return err
 			}
@@ -211,8 +233,13 @@ func addIssueCommentCommand(ctx context.Context, root *cobra.Command, options *r
 		Short: "Comment on an issue after pinned-target comparison",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(command *cobra.Command, args []string) error {
+			runtime, err := buildCommandRuntime(ctx, options)
+			if err != nil {
+				return err
+			}
 			request.ID = args[0]
-			return runIssueBodyWriteCommand(ctx, command, options, request, bodyFile)
+
+			return runIssueBodyWriteCommand(ctx, command, options, issueAdapterFor(runtime), request, bodyFile)
 		},
 	}
 	command.Flags().StringVar(&request.Body, "body", "", "comment body")
@@ -224,20 +251,17 @@ func runIssueBodyWriteCommand(
 	ctx context.Context,
 	command *cobra.Command,
 	options *rootOptions,
+	commenter issueCommenter,
 	request client.IssueCommentRequest,
 	bodyFile string,
 ) error {
-	runtime, err := buildCommandRuntime(ctx, options)
-	if err != nil {
-		return err
-	}
 	if err := resolveBodyFlag(command, &request.Body); err != nil {
 		return err
 	}
 	if err := resolveFileFlag(&request.Body, bodyFile, "body"); err != nil {
 		return err
 	}
-	comment, err := client.CommentOnIssue(ctx, runtime.graphqlClient, runtime.config.Target, request)
+	comment, err := commenter.CommentOnIssue(ctx, request)
 	if err != nil {
 		return err
 	}
@@ -256,9 +280,14 @@ func addIssueReplyCommand(ctx context.Context, root *cobra.Command, options *roo
 		Short: "Reply to an issue comment after pinned-target comparison",
 		Args:  cobra.ExactArgs(2),
 		RunE: func(command *cobra.Command, args []string) error {
+			runtime, err := buildCommandRuntime(ctx, options)
+			if err != nil {
+				return err
+			}
 			request.ID = args[0]
 			request.ParentID = args[1]
-			return runIssueBodyWriteCommand(ctx, command, options, request, bodyFile)
+
+			return runIssueBodyWriteCommand(ctx, command, options, issueAdapterFor(runtime), request, bodyFile)
 		},
 	}
 	command.Flags().StringVar(&request.Body, "body", "", "reply body")
@@ -382,7 +411,7 @@ func addIssueLinkCommand(ctx context.Context, root *cobra.Command, options *root
 			}
 			request.URL = args[0]
 			request.IssueID = args[1]
-			attachment, err := client.LinkIssueAttachment(ctx, runtime.graphqlClient, runtime.config.Target, request)
+			attachment, err := issueAdapterFor(runtime).LinkIssueAttachment(ctx, request)
 			if err != nil {
 				return err
 			}

--- a/internal/cli/issue_write.go
+++ b/internal/cli/issue_write.go
@@ -32,7 +32,16 @@ func addIssueCreateCommand(ctx context.Context, root *cobra.Command, options *ro
 		Short: "Create an issue in the pinned target",
 		Args:  cobra.NoArgs,
 		RunE: func(command *cobra.Command, _ []string) error {
-			return runIssueCreate(ctx, command, options, request, flags)
+			runtime, err := buildCommandRuntime(ctx, options)
+			if err != nil {
+				return err
+			}
+			var estimate *int
+			if command.Flags().Changed("estimate") {
+				estimate = &flags.estimate
+			}
+
+			return runIssueCreate(ctx, command, options, issueAdapterFor(runtime), request, flags, estimate)
 		},
 	}
 	command.Flags().StringVar(&request.Title, "title", "", "issue title")
@@ -60,17 +69,15 @@ func runIssueCreate(
 	ctx context.Context,
 	command *cobra.Command,
 	options *rootOptions,
+	creator issueCreator,
 	request client.IssueCreateRequest,
 	flags issueCreateFlags,
+	estimate *int,
 ) error {
-	runtime, err := buildCommandRuntime(ctx, options)
-	if err != nil {
-		return err
-	}
 	if err := resolveFileFlag(&request.Description, flags.descriptionFile, "description"); err != nil {
 		return err
 	}
-	if err := applyIssueTemplate(ctx, runtime, &request, flags.templateID); err != nil {
+	if err := applyIssueTemplate(ctx, creator, &request, flags.templateID); err != nil {
 		return err
 	}
 	if err := applyIssueSections(&request, flags.sections); err != nil {
@@ -84,13 +91,11 @@ func runIssueCreate(
 	}
 	request.StateType = stateType
 	request.Priority = normalizedPriority
-	if command.Flags().Changed("estimate") {
-		request.Estimate = &flags.estimate
-	}
+	request.Estimate = estimate
 	if flags.dryRun {
 		return writeIssueDraft(command, options, request)
 	}
-	issue, err := client.CreateIssue(ctx, runtime.graphqlClient, runtime.config.Target, request)
+	issue, err := creator.CreateIssue(ctx, request)
 	if err != nil {
 		return err
 	}
@@ -302,14 +307,25 @@ func addIssueCloseCommand(ctx context.Context, root *cobra.Command, options *roo
 			if err != nil {
 				return err
 			}
-			issue, err := client.CloseIssue(ctx, runtime.graphqlClient, runtime.config.Target, args[0])
-			if err != nil {
-				return err
-			}
 
-			return writeIssue(command, options, issue)
+			return runIssueClose(ctx, command, options, issueAdapterFor(runtime), args[0])
 		},
 	})
+}
+
+func runIssueClose(
+	ctx context.Context,
+	command *cobra.Command,
+	options *rootOptions,
+	closer issueCloser,
+	issueID string,
+) error {
+	issue, err := closer.CloseIssue(ctx, issueID)
+	if err != nil {
+		return err
+	}
+
+	return writeIssue(command, options, issue)
 }
 
 func writeIssue(command *cobra.Command, options *rootOptions, issue client.IssueSummary) error {


### PR DESCRIPTION
## What

Deepens the `internal/cli` issue command surface behind a typed **Command Port** so command logic is testable through a small domain-typed interface instead of canned GraphQL JSON.

Before, the only test seam for a command was the raw genqlient `graphql.Client`: to exercise a flag-normalization, dry-run, or error branch you had to hand-author GraphQL JSON and drive the whole command through cobra against a ~40-field fake. This PR introduces narrow, consumer-defined ports (`issueCreator`, `issueUpdater`, `issueCommenter`, `issueReader`, …) satisfied in production by a thin `issueClientAdapter` over the `client.*` free functions, and in tests by an in-memory fake. The seam moves up to domain structs, so the interface becomes the test surface.

## Scope (v1: bespoke-RunE issue commands)

Routed through the port:

- Writes with logic (logic functions + typed-fake tests): `create`, `close`, `update`, `comment`/`reply`
- Writes that are pass-throughs (adapter inline, covered by smoke + adapter forwarding test): `start`, `link`, `relate`, `unrelate`
- Reads: `list` (the all-teams-vs-resolve-team dispatch and filter assembly are logic-tested), `get`, `deps` (pass-through)

Deferred to a follow-up (the shared list-runner deepening): the shared-runner reads (`search`, `figma-file-key-search`) and the thin no-logic reads (`priority-values`, `filter-suggestion`, `title-suggestion`, `bot-actor`, `shared-access`), plus the child-list commands. These have no assembly logic, so porting them now would be shallow indirection.

## Guardrails

- The Guarded Write model (`internal/client/write_guard.go`, `target.go`, ADR-0001) is untouched: the adapter only forwards to `client.*`; the pinned/resolved target comparison stays in `internal/client`.
- The shared generic list runner (`list.go`) is untouched.
- New domain term **Command Port** added to `CONTEXT.md`.

## Tests

~15 typed-fake logic tests (normalization to canonical state/priority, template fill, dry-run skipping the port, error propagation, list dispatch and `--mine` -> viewer-id filter assembly) with zero canned GraphQL JSON, plus an adapter forwarding test that confines the canned JSON to the adapter seam.

## Gate

- `go build ./...`, `go vet ./...`, `go test ./...` green
- `task coverage` 100.0% (verified per-file; no gaps in any touched file)
- golangci-lint v2.12.2: 0 issues (narrow interfaces clear `interfacebloat`)

Also includes a small standalone test (`78048fb`) asserting guarded-write commands emit `TARGET_NOT_CONFIGURED` / `TARGET_MISMATCH` error codes on stderr.

Intended to land as one squash commit.
