### PR TITLE
Add milestone assignment and clearing to issue update

### DIFF
--- a/internal/cli/issue_write.go
+++ b/internal/cli/issue_write.go
@@ -154,6 +154,11 @@ func addIssueUpdateCommand(ctx context.Context, root *cobra.Command, options *ro
 			command.Flags().BoolVar(&request.ClearDueDate, "clear-due-date", false, "clear the due date")
 			command.Flags().IntVar(&estimate, "estimate", 0, "set the estimate (validated against team config)")
 			command.Flags().BoolVar(&request.ClearEstimate, "clear-estimate", false, "clear the estimate")
+			command.Flags().StringVar(
+				&request.ProjectMilestoneID, "milestone", "",
+				"assign to a project milestone id (requires a pinned project)",
+			)
+			command.Flags().BoolVar(&request.ClearMilestone, "clear-milestone", false, "clear the milestone")
 			registerStateCompletion(ctx, command, options)
 		},
 		Run: func(

--- a/internal/client/internal/gqlmodel/inputs.go
+++ b/internal/client/internal/gqlmodel/inputs.go
@@ -149,15 +149,16 @@ type LinearIssueRelationCreateInput struct {
 // DueDate and Estimate use RawMessage so explicit null clears the value while
 // an absent value leaves it untouched.
 type LinearIssueUpdateInput struct {
-	Title       *string         `json:"title,omitempty"`
-	Description *string         `json:"description,omitempty"`
-	AssigneeID  *string         `json:"assigneeId,omitempty"`
-	DelegateID  *string         `json:"delegateId,omitempty"`
-	StateID     *string         `json:"stateId,omitempty"`
-	Priority    *int            `json:"priority,omitempty"`
-	LabelIDs    []string        `json:"labelIds,omitempty"`
-	DueDate     json.RawMessage `json:"dueDate,omitempty"`
-	Estimate    json.RawMessage `json:"estimate,omitempty"`
+	Title              *string         `json:"title,omitempty"`
+	Description        *string         `json:"description,omitempty"`
+	AssigneeID         *string         `json:"assigneeId,omitempty"`
+	DelegateID         *string         `json:"delegateId,omitempty"`
+	StateID            *string         `json:"stateId,omitempty"`
+	Priority           *int            `json:"priority,omitempty"`
+	LabelIDs           []string        `json:"labelIds,omitempty"`
+	DueDate            json.RawMessage `json:"dueDate,omitempty"`
+	Estimate           json.RawMessage `json:"estimate,omitempty"`
+	ProjectMilestoneID json.RawMessage `json:"projectMilestoneId,omitempty"`
 }
 
 // LinearProjectCreateInput is the sparse Linear projectCreate payload linctl supports.

--- a/internal/client/issue_milestone_test.go
+++ b/internal/client/issue_milestone_test.go
@@ -1,0 +1,76 @@
+package client
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_UpdateIssue_sets_milestone_when_target_matches(t *testing.T) {
+	recorder := &recordingGraphQLClient{inner: issueWriteFakeClient(map[string]string{
+		"issue": `{"issue":` + issueJSON(b1IssueFixture("LIT-1")) + `}`,
+		"projectMilestone": `{"projectMilestone":` +
+			projectMilestoneJSON("Launch milestone", "next", "project-id") + `}`,
+		"IssueUpdate": `{"issueUpdate":{"success":true,"issue":` + issueJSON(b1IssueFixture("LIT-1")) + `}}`,
+	})}
+
+	issue, err := UpdateIssue(context.Background(), recorder, matchingTarget(), IssueUpdateRequest{
+		ID:                 "LIT-1",
+		ProjectMilestoneID: "project-milestone-id",
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, "LIT-1", issue.Identifier)
+	require.JSONEq(t, `{
+		"id": "LIT-1",
+		"input": {"projectMilestoneId": "project-milestone-id"}
+	}`, string(recorder.variablesFor(t, "IssueUpdate")))
+}
+
+func Test_UpdateIssue_clears_milestone_when_requested(t *testing.T) {
+	recorder := &recordingGraphQLClient{inner: issueWriteFakeClient(map[string]string{
+		"issue":       `{"issue":` + issueJSON(b1IssueFixture("LIT-1")) + `}`,
+		"IssueUpdate": `{"issueUpdate":{"success":true,"issue":` + issueJSON(b1IssueFixture("LIT-1")) + `}}`,
+	})}
+
+	issue, err := UpdateIssue(context.Background(), recorder, matchingTarget(), IssueUpdateRequest{
+		ID:             "LIT-1",
+		ClearMilestone: true,
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, "LIT-1", issue.Identifier)
+	require.JSONEq(t, `{
+		"id": "LIT-1",
+		"input": {"projectMilestoneId": null}
+	}`, string(recorder.variablesFor(t, "IssueUpdate")))
+}
+
+func Test_UpdateIssue_rejects_milestone_with_clear_milestone(t *testing.T) {
+	graphqlClient := issueWriteFakeClient(map[string]string{})
+
+	_, err := UpdateIssue(context.Background(), graphqlClient, matchingTarget(), IssueUpdateRequest{
+		ID:                 "LIT-1",
+		ProjectMilestoneID: "project-milestone-id",
+		ClearMilestone:     true,
+	})
+
+	require.ErrorIs(t, err, ErrWriteInvalid)
+}
+
+func Test_UpdateIssue_refuses_milestone_from_a_different_project(t *testing.T) {
+	graphqlClient := issueWriteFakeClient(map[string]string{
+		"issue": `{"issue":` + issueJSON(b1IssueFixture("LIT-1")) + `}`,
+		"projectMilestone": `{"projectMilestone":` +
+			projectMilestoneJSON("Wrong project milestone", "next", "other-project") + `}`,
+	})
+
+	_, err := UpdateIssue(context.Background(), graphqlClient, matchingTarget(), IssueUpdateRequest{
+		ID:                 "LIT-1",
+		ProjectMilestoneID: "project-milestone-id",
+	})
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrTargetMismatch)
+}

--- a/internal/client/issue_write.go
+++ b/internal/client/issue_write.go
@@ -41,18 +41,20 @@ type IssueCreateRequest struct {
 
 // IssueUpdateRequest describes a guarded issue update.
 type IssueUpdateRequest struct {
-	ID            string
-	Title         string
-	Description   string
-	Append        string
-	StateType     string
-	Priority      string
-	AssigneeID    string
-	LabelIDs      []string
-	DueDate       string
-	ClearDueDate  bool
-	Estimate      *int
-	ClearEstimate bool
+	ID                 string
+	Title              string
+	Description        string
+	Append             string
+	StateType          string
+	Priority           string
+	AssigneeID         string
+	LabelIDs           []string
+	DueDate            string
+	ClearDueDate       bool
+	Estimate           *int
+	ClearEstimate      bool
+	ProjectMilestoneID string
+	ClearMilestone     bool
 }
 
 // IssueCommentRequest describes a guarded issue comment.
@@ -238,6 +240,20 @@ func (guard *guardedClient) requireCreateMilestone(
 	return guard.requireProjectMilestone(ctx, projectMilestoneID)
 }
 
+// requireUpdateMilestone validates a milestone assignment on update the same way
+// create does; a clear needs no validation because it removes the assignment
+// rather than pointing at one that must exist in the pinned project.
+func (guard *guardedClient) requireUpdateMilestone(
+	ctx context.Context,
+	request IssueUpdateRequest,
+) error {
+	if request.ClearMilestone {
+		return nil
+	}
+
+	return guard.requireCreateMilestone(ctx, request.ProjectMilestoneID)
+}
+
 // UpdateIssue updates an issue after resolving and comparing the pinned write target.
 func UpdateIssue(
 	ctx context.Context,
@@ -266,6 +282,9 @@ func (guard *guardedClient) updateIssue(ctx context.Context, request IssueUpdate
 		return IssueSummary{}, err
 	}
 	if err = guard.requireAttachableLabels(ctx, request.LabelIDs); err != nil {
+		return IssueSummary{}, err
+	}
+	if err = guard.requireUpdateMilestone(ctx, request); err != nil {
 		return IssueSummary{}, err
 	}
 	description := request.Description
@@ -307,6 +326,9 @@ func validateIssueUpdateRequest(request IssueUpdateRequest) error {
 	if request.Estimate != nil && request.ClearEstimate {
 		return fmt.Errorf("%w: estimate and clear-estimate are mutually exclusive", ErrWriteInvalid)
 	}
+	if request.ProjectMilestoneID != "" && request.ClearMilestone {
+		return fmt.Errorf("%w: milestone and clear-milestone are mutually exclusive", ErrWriteInvalid)
+	}
 
 	return validateDueDate(request.DueDate)
 }
@@ -315,7 +337,8 @@ func issueUpdateHasNoFields(request IssueUpdateRequest) bool {
 	return request.Title == "" && request.Description == "" && request.Append == "" &&
 		request.StateType == "" && request.Priority == "" && request.AssigneeID == "" &&
 		len(request.LabelIDs) == 0 && request.DueDate == "" && !request.ClearDueDate &&
-		request.Estimate == nil && !request.ClearEstimate
+		request.Estimate == nil && !request.ClearEstimate &&
+		request.ProjectMilestoneID == "" && !request.ClearMilestone
 }
 
 func (guard *guardedClient) buildIssueUpdateInput(
@@ -325,12 +348,13 @@ func (guard *guardedClient) buildIssueUpdateInput(
 	description string,
 ) (LinearIssueUpdateInput, error) {
 	input := LinearIssueUpdateInput{
-		Title:       optionalString(request.Title),
-		Description: optionalString(description),
-		AssigneeID:  optionalString(request.AssigneeID),
-		LabelIDs:    request.LabelIDs,
-		DueDate:     dueDateUpdateJSON(request),
-		Estimate:    estimateUpdateJSON(request),
+		Title:              optionalString(request.Title),
+		Description:        optionalString(description),
+		AssigneeID:         optionalString(request.AssigneeID),
+		LabelIDs:           request.LabelIDs,
+		DueDate:            dueDateUpdateJSON(request),
+		Estimate:           estimateUpdateJSON(request),
+		ProjectMilestoneID: projectMilestoneUpdateJSON(request),
 	}
 	if request.StateType != "" {
 		stateID, err := guard.stateIDOfType(ctx, teamID, request.StateType)
@@ -681,4 +705,17 @@ func estimateUpdateJSON(request IssueUpdateRequest) json.RawMessage {
 	}
 
 	return json.RawMessage(strconv.Itoa(*request.Estimate))
+}
+
+// projectMilestoneUpdateJSON renders the issueUpdate projectMilestoneId field: an
+// explicit null to clear it, a quoted id to set it, or nil to leave it untouched.
+func projectMilestoneUpdateJSON(request IssueUpdateRequest) json.RawMessage {
+	if request.ClearMilestone {
+		return json.RawMessage("null")
+	}
+	if request.ProjectMilestoneID == "" {
+		return nil
+	}
+
+	return json.RawMessage(strconv.Quote(request.ProjectMilestoneID))
 }

--- a/skills/linctl/references/commands.md
+++ b/skills/linctl/references/commands.md
@@ -2022,11 +2022,13 @@ Flags:
       --assignee string           reassign the issue to a user id
       --clear-due-date            clear the due date
       --clear-estimate            clear the estimate
+      --clear-milestone           clear the milestone
       --description string        new issue description
       --description-file string   read new issue description from file
       --due-date string           set the due date (YYYY-MM-DD)
       --estimate int              set the estimate (validated against team config)
       --label stringArray         set labels by id (repeatable, replaces existing)
+      --milestone string          assign to a project milestone id (requires a pinned project)
       --priority string           set priority (urgent/high/medium/low/none or 0-4)
       --state string              set workflow state type (e.g. started, completed)
       --status string             alias for --state


### PR DESCRIPTION
## What

`issue update` now supports `--milestone <id>` (assign) and `--clear-milestone` (remove), closing the gap where a milestone could only be set at `issue create` time. Reassigning or unbucketing an existing issue no longer requires the Linear UI.

## How

- `LinearIssueUpdateInput` carries `projectMilestoneId` as a null-capable `json.RawMessage`, the same pattern `dueDate` and `estimate` already use: an explicit `null` clears, a quoted id sets, an absent value leaves it untouched.
- The two flags are mutually exclusive, validated fail-closed.
- A set validates the milestone belongs to the pinned project through the same guard `create` uses; a clear needs no validation because it removes the assignment rather than pointing at one that must exist.
- The generated command reference is regenerated.

## Tests

`internal/client/issue_milestone_test.go`: set sends the quoted id, clear sends `projectMilestoneId: null` (asserted on the recorded mutation variables, not just the happy path), the flags are mutually exclusive, and an out-of-project milestone is refused with a target mismatch.

Local gate green: gofumpt fmt-check, vet, golangci-lint v2.12.2 (0 issues), race and shuffle tests across all packages, hand-written coverage 100%.
